### PR TITLE
chore: SIGTERM instead of killing the service

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"reflect"
 	"sync"
+	"syscall"
 	"time"
 
 	"rules_itest/logger"
@@ -136,7 +137,7 @@ func prepareServiceInstance(ctx context.Context, s svclib.VersionedServiceSpec) 
 }
 
 func stopInstance(serviceInstance *ServiceInstance) {
-	serviceInstance.Cmd.Process.Kill()
+	serviceInstance.Cmd.Process.Signal(syscall.SIGTERM)
 	serviceInstance.Cmd.Wait()
 
 	for serviceInstance.Cmd.ProcessState == nil {


### PR DESCRIPTION
# Summary

`SIGKILL` doesn't seem to work cleanly with [`js_binary`](https://docs.aspect.build/rulesets/aspect_rules_js/docs/js_binary/#js_binary), which underneath generates a shell script as an entrypoint - the services will simply hang. Changing it to `SIGTERM` seems to address all the issue.

Open to feedback for alternatives.

# Test Plan

Hyerbase services no long hang. Also,

```
(env-18.16.0) bz@at-dev ~/r/examples (master) > bazel test //:speedy_service_hygiene_test
INFO: Invocation ID: f0714527-0ee0-4717-bb06-956efe3ee3a3
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/f0714527-0ee0-4717-bb06-956efe3ee3a3
INFO: Analyzed target //:speedy_service_hygiene_test (101 packages loaded, 10715 targets configured).
INFO: Found 1 test target...
INFO: From GoLink go_service/go_service_/go_service:
ld: warning: ignoring duplicate libraries: '-lm'
INFO: From GoLink external/rules_itest~override/cmd/svcinit/svcinit_/svcinit:
ld: warning: ignoring duplicate libraries: '-lm'
Target //:speedy_service_hygiene_test up-to-date:
  bazel-bin/speedy_service_hygiene_test
INFO: Elapsed time: 14.700s, Critical Path: 12.51s
INFO: 18 processes: 8 internal, 9 darwin-sandbox, 1 local.
INFO: Build completed successfully, 18 total actions
//:speedy_service_hygiene_test                                           PASSED in 0.7s

Executed 1 out of 1 test: 1 test passes.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/f0714527-0ee0-4717-bb06-956efe3ee3a3
(env-18.16.0) bz@at-dev ~/r/examples (master) > git st
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
(env-18.16.0) bz@at-dev ~/r/examples (master) > bazel test //:sleepy_service_hygiene_test
INFO: Invocation ID: 3998672d-b536-4f80-97af-62ccc60a907b
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/3998672d-b536-4f80-97af-62ccc60a907b
INFO: Analyzed target //:sleepy_service_hygiene_test (0 packages loaded, 2 targets configured).
INFO: Found 1 test target...
Target //:sleepy_service_hygiene_test up-to-date:
  bazel-bin/sleepy_service_hygiene_test
INFO: Elapsed time: 1.529s, Critical Path: 0.76s
INFO: 10 processes: 7 internal, 2 darwin-sandbox, 1 local.
INFO: Build completed successfully, 10 total actions
//:sleepy_service_hygiene_test                                           PASSED in 0.1s

Executed 1 out of 1 test: 1 test passes.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/3998672d-b536-4f80-97af-62ccc60a907b
```