### PR TITLE
Add direct support for health check arguments

### DIFF
--- a/cmd/svcinit/main.go
+++ b/cmd/svcinit/main.go
@@ -385,11 +385,18 @@ func augmentServiceSpecs(
 				s.Args[i] = strings.ReplaceAll(s.Args[i], "$${PORT}", port)
 			}
 			s.HttpHealthCheckAddress = strings.ReplaceAll(s.HttpHealthCheckAddress, "$${PORT}", port)
+			for i := range s.ServiceSpec.HealthCheckArgs {
+				s.HealthCheckArgs[i] = strings.ReplaceAll(s.HealthCheckArgs[i], "$${PORT}", port)
+			}
 		}
 
 		for i := range s.Args {
 			s.Args[i] = strings.ReplaceAll(s.Args[i], "$${TMPDIR}", tmpDir)
 			s.Args[i] = strings.ReplaceAll(s.Args[i], "$${SOCKET_DIR}", socketDir)
+		}
+		for i := range s.HealthCheckArgs {
+			s.HealthCheckArgs[i] = strings.ReplaceAll(s.HealthCheckArgs[i], "$${TMPDIR}", tmpDir)
+			s.HealthCheckArgs[i] = strings.ReplaceAll(s.HealthCheckArgs[i], "$${SOCKET_DIR}", socketDir)
 		}
 
 		versionedServiceSpecs[label] = s
@@ -408,6 +415,9 @@ func augmentServiceSpecs(
 			spec.HttpHealthCheckAddress = strings.ReplaceAll(spec.HttpHealthCheckAddress, r.Old, r.New)
 			for i := range spec.Args {
 				spec.Args[i] = strings.ReplaceAll(spec.Args[i], r.Old, r.New)
+			}
+			for i := range spec.ServiceSpec.HealthCheckArgs {
+				spec.HealthCheckArgs[i] = strings.ReplaceAll(spec.HealthCheckArgs[i], r.Old, r.New)
 			}
 		}
 		versionedServiceSpecs[label] = spec

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -3,9 +3,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "com_github_redis_redis",
     build_file = "//redis:BUILD.redis",
-    urls = ["https://github.com/redis/redis/archive/refs/tags/6.2.6.tar.gz"],
-    sha256 = "5d452038e346b5f31d7d277a41a4ec583bc8bf04403db620403638f79bdda891",
-    strip_prefix = "redis-6.2.6",
+    sha256 = "23ae46360514b25fa596ac2b3140ccb93282c2a16fe5f6d8a4d3e833610d66ac",
+    strip_prefix = "redis-6.2.14",
+    urls = ["https://github.com/redis/redis/archive/refs/tags/6.2.14.tar.gz"],
 )
 
 http_archive(
@@ -17,4 +17,5 @@ http_archive(
 )
 
 load("//mysql:repositories.bzl", "mysql_repositories")
+
 mysql_repositories()

--- a/examples/mysql/BUILD.bazel
+++ b/examples/mysql/BUILD.bazel
@@ -36,22 +36,6 @@ mysql_impl(
 # =================================================================================================== #
 # ============================================ Socket version ======================================= #
 # =================================================================================================== #
-genrule(
-    name = "gen_socket_health_check",
-    srcs = [":mysql_cli"],
-    outs = ["socket_health_check.sh"],
-    cmd = """echo '#!/bin/sh
-MYSQL_CLI=$(rootpath :mysql_cli)
-set -x
-exec "$$MYSQL_CLI" --no-defaults --socket "$$SOCKET_DIR/mysql.sock" --user user --password="password" -e "SELECT 1"' > $@""",
-)
-
-sh_binary(
-    name = "socket_health_check",
-    srcs = ["socket_health_check.sh"],
-    data = [":mysql_cli"],
-)
-
 itest_service(
     name = "mysql_listening_on_socket",
     args = [
@@ -61,30 +45,22 @@ itest_service(
     ],
     exe = ":with_migrations",
     health_check = ":socket_health_check",
+    health_check_args = [
+        "--no-defaults",
+        "--socket",
+        "$${SOCKET_DIR}/mysql.sock",
+        "--user",
+        "user",
+        "--password=password",
+        "-e",
+        "SELECT 1",
+    ],
     visibility = ["//visibility:public"],
 )
 
 # =================================================================================================== #
 # ============================================ Port version ======================================= #
 # =================================================================================================== #
-
-sh_binary(
-    name = "port_health_check",
-    srcs = ["port_health_check.sh"],
-    data = [":mysql_cli"],
-)
-
-genrule(
-    name = "gen_port_health_check",
-    srcs = [":mysql_cli"],
-    outs = ["port_health_check.sh"],
-    cmd = """echo '#!/bin/sh
-MYSQL_CLI=$(rootpath :mysql_cli)
-PORT=$$($$GET_ASSIGNED_PORT_BIN @@//mysql:mysql_listening_on_port)
-set -x
-exec "$$MYSQL_CLI" --no-defaults --protocol tcp --host 127.0.0.1 --port "$$PORT" --user root -e "SELECT 1"' > $@""",
-)
-
 itest_service(
     name = "mysql_listening_on_port",
     args = [
@@ -95,6 +71,19 @@ itest_service(
     ],
     autoassign_port = True,
     exe = ":with_migrations",
-    health_check = ":port_health_check",
+    health_check = ":mysql_cli",
+    health_check_args = [
+        "--no-defaults",
+        "--protocol",
+        "tcp",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "$${PORT}",
+        "--user",
+        "root",
+        "-e",
+        "SELECT 1",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/examples/mysql/BUILD.bazel
+++ b/examples/mysql/BUILD.bazel
@@ -44,7 +44,7 @@ itest_service(
         "$${SOCKET_DIR}/mysql.sock",
     ],
     exe = ":with_migrations",
-    health_check = ":socket_health_check",
+    health_check = ":mysql_cli",
     health_check_args = [
         "--no-defaults",
         "--socket",

--- a/examples/redis/BUILD.bazel
+++ b/examples/redis/BUILD.bazel
@@ -1,11 +1,5 @@
 load("@rules_itest//:itest.bzl", "itest_service")
 
-sh_binary(
-    name = "health_check",
-    srcs = ["health_check.sh"],
-    data = ["@com_github_redis_redis//:redis_cli"],
-)
-
 itest_service(
     name = "redis",
     args = [
@@ -19,5 +13,10 @@ itest_service(
         "$${TMPDIR}",
     ],
     exe = "@com_github_redis_redis//:redis",
-    health_check = ":health_check",
+    health_check = "@com_github_redis_redis//:redis_cli",
+    health_check_args = [
+        "-s",
+        "$${TMPDIR}/redis.sock",
+        "PING",
+    ],
 )

--- a/examples/redis/health_check.sh
+++ b/examples/redis/health_check.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-exec ../com_github_redis_redis/redis_cli -s "$TMPDIR/redis.sock" PING

--- a/private/itest.bzl
+++ b/private/itest.bzl
@@ -146,6 +146,7 @@ def _itest_service_impl(ctx):
     extra_exe_runfiles = []
 
     if ctx.attr.health_check:
+        extra_service_spec_kwargs["health_check_label"] = str(ctx.attr.health_check.label)
         extra_service_spec_kwargs["health_check"] = to_rlocation_path(ctx, ctx.executable.health_check)
         extra_exe_runfiles.append(ctx.attr.health_check.default_runfiles)
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -237,6 +237,10 @@ func prepareServiceInstance(ctx context.Context, s svclib.VersionedServiceSpec) 
 }
 
 func stopInstance(serviceInstance *ServiceInstance) {
+	if serviceInstance.Cmd.Process == nil {
+		return
+	}
+
 	pid := serviceInstance.Cmd.Process.Pid
 	if shouldUseProcessGroups {
 		pid = -pid

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -46,6 +46,10 @@ func New(ctx context.Context, serviceSpecs ServiceSpecs) (*runner, error) {
 	return r, nil
 }
 
+func colorize(s svclib.VersionedServiceSpec) string {
+	return s.Colorize(s.Label)
+}
+
 func (r *runner) StartAll() ([]topological.Task, error) {
 	tasks := allTasks(r.serviceInstances, func(ctx context.Context, service *ServiceInstance) error {
 		if service.Type == "group" {

--- a/runner/service_instance.go
+++ b/runner/service_instance.go
@@ -68,9 +68,9 @@ func (s *ServiceInstance) WaitUntilHealthy(ctx context.Context) error {
 			return err
 		}
 
-		log.Printf("Healthchecking %s (pid %d)\n", coloredLabel, s.Process.Pid)
-
 		if s.HttpHealthCheckAddress != "" {
+			log.Printf("HTTP Healthchecking %s (pid %d) : %s\n", coloredLabel, s.Process.Pid, s.HttpHealthCheckAddress)
+
 			var resp *http.Response
 			resp, err = http.DefaultClient.Get(s.HttpHealthCheckAddress)
 			if resp != nil {
@@ -85,6 +85,7 @@ func (s *ServiceInstance) WaitUntilHealthy(ctx context.Context) error {
 			}
 
 		} else if s.HealthCheck != "" {
+			log.Printf("CMD Healthchecking %s (pid %d) : %v\n", colorize(s.VersionedServiceSpec), s.Process.Pid, s.VersionedServiceSpec.HealthCheckArgs)
 			cmd := exec.CommandContext(ctx, s.HealthCheck, s.VersionedServiceSpec.HealthCheckArgs...)
 			cmd.Stdout = logger.New(s.Label+"? ", s.Color, os.Stdout)
 			cmd.Stderr = logger.New(s.Label+"? ", s.Color, os.Stderr)

--- a/runner/service_instance.go
+++ b/runner/service_instance.go
@@ -15,10 +15,6 @@ import (
 	"rules_itest/svclib"
 )
 
-func colorize(s svclib.VersionedServiceSpec) string {
-	return s.Color + s.Label + logger.Reset
-}
-
 type ServiceInstance struct {
 	svclib.VersionedServiceSpec
 	*exec.Cmd
@@ -50,7 +46,7 @@ func (s *ServiceInstance) WaitUntilHealthy(ctx context.Context) error {
 		return nil
 	}
 
-	coloredLabel := colorize(s.VersionedServiceSpec)
+	coloredLabel := s.Colorize(s.Label)
 	if s.Type == "task" {
 		err := s.waitErrFn()
 		log.Printf("%s completed.\n", coloredLabel)
@@ -85,7 +81,7 @@ func (s *ServiceInstance) WaitUntilHealthy(ctx context.Context) error {
 			}
 
 		} else if s.HealthCheck != "" {
-			log.Printf("CMD Healthchecking %s (pid %d) : %v\n", colorize(s.VersionedServiceSpec), s.Process.Pid, s.VersionedServiceSpec.HealthCheckArgs)
+			log.Printf("CMD Healthchecking %s (pid %d) : %v\n", s.Colorize(s.HealthCheckLabel), s.Process.Pid, s.VersionedServiceSpec.HealthCheckArgs)
 			cmd := exec.CommandContext(ctx, s.HealthCheck, s.VersionedServiceSpec.HealthCheckArgs...)
 			cmd.Stdout = logger.New(s.Label+"? ", s.Color, os.Stdout)
 			cmd.Stderr = logger.New(s.Label+"? ", s.Color, os.Stderr)

--- a/runner/service_instance.go
+++ b/runner/service_instance.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"time"
 
@@ -81,7 +82,7 @@ func (s *ServiceInstance) WaitUntilHealthy(ctx context.Context) error {
 			}
 
 		} else if s.HealthCheck != "" {
-			log.Printf("CMD Healthchecking %s (pid %d) : %v\n", s.Colorize(s.HealthCheckLabel), s.Process.Pid, s.VersionedServiceSpec.HealthCheckArgs)
+			log.Printf("CMD Healthchecking %s (pid %d) : %s %v\n", coloredLabel, s.Process.Pid, s.Colorize(s.HealthCheckLabel), strings.Join(s.VersionedServiceSpec.HealthCheckArgs, " "))
 			cmd := exec.CommandContext(ctx, s.HealthCheck, s.VersionedServiceSpec.HealthCheckArgs...)
 			cmd.Stdout = logger.New(s.Label+"? ", s.Color, os.Stdout)
 			cmd.Stderr = logger.New(s.Label+"? ", s.Color, os.Stderr)

--- a/svclib/BUILD.bazel
+++ b/svclib/BUILD.bazel
@@ -8,4 +8,7 @@ go_library(
     ],
     importpath = "rules_itest/svclib",
     visibility = ["//visibility:public"],
+    deps = [
+        "//logger",
+    ],
 )

--- a/svclib/types.go
+++ b/svclib/types.go
@@ -10,6 +10,7 @@ type ServiceSpec struct {
 	Exe                    string            `json:"exe"`
 	HttpHealthCheckAddress string            `json:"http_health_check_address"`
 	HealthCheck            string            `json:"health_check"`
+	HealthCheckArgs        []string          `json:"health_check_args"`
 	VersionFile            string            `json:"version_file"`
 	Deps                   []string          `json:"deps"`
 	AutoassignPort         bool              `json:"autoassign_port"`

--- a/svclib/types.go
+++ b/svclib/types.go
@@ -1,5 +1,7 @@
 package svclib
 
+import "rules_itest/logger"
+
 // Created by Starlark
 type ServiceSpec struct {
 	// Type can be "service", "task", or "group".
@@ -10,6 +12,7 @@ type ServiceSpec struct {
 	Exe                    string            `json:"exe"`
 	HttpHealthCheckAddress string            `json:"http_health_check_address"`
 	HealthCheck            string            `json:"health_check"`
+	HealthCheckLabel       string            `json:"health_check_label"`
 	HealthCheckArgs        []string          `json:"health_check_args"`
 	VersionFile            string            `json:"version_file"`
 	Deps                   []string          `json:"deps"`
@@ -23,4 +26,8 @@ type VersionedServiceSpec struct {
 	ServiceSpec
 	Version string
 	Color   string
+}
+
+func (v VersionedServiceSpec) Colorize(label string) string {
+	return v.Color + label + logger.Reset
 }


### PR DESCRIPTION
```
00:23:14 rlavoie ~/rlavoie/darkrift/rules_itest/examples (health_check_args) $ bazel run //redis:redis
INFO: Analyzed target //redis:redis (0 packages loaded, 0 targets configured).
INFO: From GoLink external/rules_itest~/cmd/svcinit/svcinit_/svcinit:
ld: warning: ignoring duplicate libraries: '-lm'
INFO: Found 1 target...
Target //redis:redis up-to-date:
  bazel-bin/redis/redis
INFO: Elapsed time: 1.968s, Critical Path: 1.74s
INFO: 5 processes: 2 internal, 3 darwin-sandbox.
INFO: Build completed successfully, 5 total actions
INFO: Running command line: bazel-bin/redis/redis --port 0 --unixsocket '${TMPDIR}/redis.sock' --unixsocketperm 770 --dir '${TMPDIR}'
2024/05/25 00:23:37 Starting @@//redis:redis [--port 0 --unixsocket /var/folders/mp/95j4zyhx5yb8fm2lvvn0211r0000gn/T/3691759531/redis.sock --unixsocketperm 770 --dir /var/folders/mp/95j4zyhx5yb8fm2lvvn0211r0000gn/T/3691759531]
2024/05/25 00:23:37 CMD Healthchecking @@//redis:redis (pid 89470) : @@com_github_redis_redis//:redis_cli -s /var/folders/mp/95j4zyhx5yb8fm2lvvn0211r0000gn/T/3691759531/redis.sock PING
@@//redis:redis? Could not connect to Redis at /var/folders/mp/95j4zyhx5yb8fm2lvvn0211r0000gn/T/3691759531/redis.sock: No such file or directory
exit status 1
@@//redis:redis> 89470:C 25 May 2024 00:23:37.940 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
@@//redis:redis> 89470:C 25 May 2024 00:23:37.941 # Redis version=6.2.14, bits=64, commit=00000000, modified=0, pid=89470, just started
@@//redis:redis> 89470:C 25 May 2024 00:23:37.941 # Configuration loaded
@@//redis:redis> 89470:M 25 May 2024 00:23:37.941 * monotonic clock: POSIX clock_gettime
@@//redis:redis> 89470:M 25 May 2024 00:23:37.942 * Running mode=standalone, port=0.
@@//redis:redis> 89470:M 25 May 2024 00:23:37.942 # Server initialized
@@//redis:redis> 89470:M 25 May 2024 00:23:37.942 * The server is now ready to accept connections at /var/folders/mp/95j4zyhx5yb8fm2lvvn0211r0000gn/T/3691759531/redis.sock
2024/05/25 00:23:38 CMD Healthchecking @@//redis:redis (pid 89470) : @@com_github_redis_redis//:redis_cli -s /var/folders/mp/95j4zyhx5yb8fm2lvvn0211r0000gn/T/3691759531/redis.sock PING
@@//redis:redis? PONG
2024/05/25 00:23:38 @@//redis:redis healthy!

Target                 Critical Path Contribution
@@//redis:redis        214.90475ms

Target                 Startup Time
@@//redis:redis        214.90475ms

^C2024/05/25 00:23:51 Shutdown requested, exiting gracefully. Press Ctrl-C again to force exit
2024/05/25 00:23:51 Shutting down services.
2024/05/25 00:23:51 Stopping @@//redis:redis
2024/05/25 00:23:51 Cleaning up.
```

Bonus: Fix a seg fault if one of the dependencies finished early and the test timeout:
```
-- Test timed out at 2024-05-25 04:54:59 UTC --
@@//cproc/tests:redis> 7545:signal-handler (1716612899) Received SIGTERM scheduling shutdown...
2024/05/25 04:54:59 Shutdown requested, exiting gracefully. Press Ctrl-C again to force exit
2024/05/25 04:54:59 Stopping @@//cproc/services/domain-valet/tests:domain-valet
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1049fff24]

goroutine 2302 [running]:
rules_itest/runner.stopInstance(0x1400022c480)
	external/rules_itest~/runner/runner.go:240 +0x24
rules_itest/runner.(*runner).StopAll.func1({0x1400007e720?, 0x14000114230?}, 0x1400022c480)
	external/rules_itest~/runner/runner.go:76 +0x160
rules_itest/runner.(*topoTask).Run(0x140003a6f48?, {0x104b0dbe0?, 0x14000224000?})
	external/rules_itest~/runner/topo.go:23 +0x3c
rules_itest/runner/topological.(*reversedTask).Run(0x14000234070?, {0x104b0dbe0?, 0x14000224000?})
	external/rules_itest~/runner/topological/runner.go:66 +0x30
rules_itest/runner/topological.(*runner).worker(0x14000234070, {0x104b0dbe0, 0x14000224000}, 0x140002c6120?)
	external/rules_itest~/runner/topological/runner.go:189 +0xa0
created by rules_itest/runner/topological.(*runner).Run in goroutine 1
	external/rules_itest~/runner/topological/runner.go:205 +0x48
```