### PR TITLE
feat: adds health check timeout support

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -59,6 +59,15 @@ func (r *runner) StartAll() ([]topological.Task, error) {
 		if startErr != nil {
 			return startErr
 		}
+		if service.VersionedServiceSpec.HealthCheckTimeout != "" {
+			timeout, err := time.ParseDuration(service.VersionedServiceSpec.HealthCheckTimeout)
+			if err != nil {
+				log.Printf("failed to parse health check timeout, falling back to no timeout: %v", err)
+			}
+			timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+			ctx = timeoutCtx
+			defer cancel()
+		}
 		return service.WaitUntilHealthy(ctx)
 	})
 	starter := topological.NewRunner(tasks)

--- a/runner/service_instance.go
+++ b/runner/service_instance.go
@@ -56,7 +56,7 @@ func (s *ServiceInstance) WaitUntilHealthy(ctx context.Context) error {
 
 	sleepDuration, err := time.ParseDuration(s.VersionedServiceSpec.HealthCheckInterval)
 	if err != nil {
-		log.Printf("failed to parse time duration, falling back to 200ms: %v", err)
+		log.Printf("failed to parse health check time duration, falling back to 200ms: %v", err)
 		// This should really not happen if we validate it properly in starlark
 		sleepDuration = time.Duration(200) * time.Millisecond
 	}

--- a/svclib/types.go
+++ b/svclib/types.go
@@ -15,6 +15,7 @@ type ServiceSpec struct {
 	HealthCheckLabel       string            `json:"health_check_label"`
 	HealthCheckArgs        []string          `json:"health_check_args"`
 	HealthCheckInterval    string            `json:"health_check_interval"`
+	HealthCheckTimeout     string            `json:"health_check_timeout"`
 	VersionFile            string            `json:"version_file"`
 	Deps                   []string          `json:"deps"`
 	AutoassignPort         bool              `json:"autoassign_port"`


### PR DESCRIPTION
This PR introduces the health check timeout support for `itest_service`. By default, the `health_check_timeout` is empty, which means there is no timeout. But users can specify human readable durations to specify the timeout of the health check.