### PR TITLE
fix: collect runfiles from itest_service data attribute

### DIFF
--- a/private/itest.bzl
+++ b/private/itest.bzl
@@ -127,7 +127,7 @@ def _itest_binary_impl(ctx, extra_service_spec_kwargs, extra_exe_runfiles = []):
         direct_runfiles.append(version_file)
 
     runfiles = ctx.runfiles(direct_runfiles)
-    runfiles = runfiles.merge_all(_services_runfiles(ctx, "deps") + exe_runfiles)
+    runfiles = runfiles.merge_all(_services_runfiles(ctx, "data") + _services_runfiles(ctx, "deps") + exe_runfiles)
 
     return [
         RunEnvironmentInfo(environment = _run_environment(ctx, service_specs_file)),


### PR DESCRIPTION
If a itest_service is simply a wrapper that invokes another target passed from the command line, we need the runfiles of the target as well.