### PR TITLE
chore: do not set TEST_TMPDIR

### DIFF
--- a/cmd/svcinit/main.go
+++ b/cmd/svcinit/main.go
@@ -76,7 +76,11 @@ func main() {
 		defer os.RemoveAll(tmpDir)
 	}
 	os.Setenv("TEST_TMPDIR", tmpDir)
-	os.Setenv("TMPDIR", tmpDir)
+
+	// Provide a TMPDIR if one is not set.
+	if _, ok := os.LookupEnv("TMPDIR"); !ok {
+		os.Setenv("TMPDIR", os.TempDir())
+	}
 
 	getAssignedPortBinPath, err := runfiles.Rlocation(os.Getenv("SVCINIT_GET_ASSIGNED_PORT_BIN_RLOCATION_PATH"))
 	must(err)


### PR DESCRIPTION
The responsibility of how to TEST_TMPDIR vs TMPDIR is better handled by the services or the test runners.