### PR TITLE
chore: only bind socket without listening

### DIFF
--- a/cmd/svcinit/set_sockopts_for_port_assignment_unix.go
+++ b/cmd/svcinit/set_sockopts_for_port_assignment_unix.go
@@ -8,12 +8,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func setSockoptsForPortAssignment(fd uintptr, l *syscall.Linger) error {
-	err := syscall.SetsockoptLinger(int(fd), syscall.SOL_SOCKET, syscall.SO_LINGER, l)
-	if err != nil {
-		return err
-	}
+type Fd = int
 
+func setSockoptsForPortAssignment(fd int) error {
 	// It's unfortunate that we need `unix` here; SO_REUSEPORT is defined on linuxarm64 but not linux...
-	return syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+	return syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1)
 }

--- a/cmd/svcinit/set_sockopts_for_port_assignment_windows.go
+++ b/cmd/svcinit/set_sockopts_for_port_assignment_windows.go
@@ -4,7 +4,9 @@ package main
 
 import "syscall"
 
-func setSockoptsForPortAssignment(fd uintptr, l *syscall.Linger) error {
+type Fd = syscall.Handle
+
+func setSockoptsForPortAssignment(fd syscall.Handle) error {
 	// Windows (even WSL) does not seem to support SO_REUSEPORT
-	return syscall.SetsockoptLinger(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_LINGER, l)
+	return nil
 }


### PR DESCRIPTION
This PR cleans up the port assignment code to only bind the socket without listening.