### PR TITLE
Fix TEST_TMPDIR missing replacement

### DIFF
--- a/cmd/svcinit/main.go
+++ b/cmd/svcinit/main.go
@@ -172,7 +172,6 @@ func main() {
 		var testCmd *exec.Cmd
 		testErrCh := make(chan error, 1)
 		if testLabel != "" {
-			// TODO replace these
 			testArgs := os.Args[1:]
 
 			for i := range testArgs {

--- a/cmd/svcinit/main.go
+++ b/cmd/svcinit/main.go
@@ -184,7 +184,6 @@ func main() {
 			testPath, err := runfiles.Rlocation(os.Getenv("SVCINIT_TEST_RLOCATION_PATH"))
 			must(err)
 
-			// TODO Should this also replace SOCKET_DIR, TMPDIR and TEST_TMPDIR ?
 			testEnv, err := buildTestEnv(replacements)
 			must(err)
 

--- a/cmd/svcinit/main.go
+++ b/cmd/svcinit/main.go
@@ -181,6 +181,7 @@ func main() {
 			testPath, err := runfiles.Rlocation(os.Getenv("SVCINIT_TEST_RLOCATION_PATH"))
 			must(err)
 
+			// TODO Should this also replace SOCKET_DIR, TMPDIR and TEST_TMPDIR ?
 			testEnv, err := buildTestEnv(ports)
 			must(err)
 

--- a/cmd/svcinit/main.go
+++ b/cmd/svcinit/main.go
@@ -384,6 +384,7 @@ func augmentServiceSpecs(
 	map[string]svclib.VersionedServiceSpec, error,
 ) {
 	tmpDir := os.Getenv("TMPDIR")
+	testTmpDir := os.Getenv("TEST_TMPDIR")
 	socketDir := os.Getenv("SOCKET_DIR")
 
 	versionedServiceSpecs := make(map[string]svclib.VersionedServiceSpec, len(serviceSpecs))
@@ -446,6 +447,7 @@ func augmentServiceSpecs(
 	replacements := make([]Replacement, 0, 2+len(ports))
 	replacements = append(replacements,
 		Replacement{Old: "$${TMPDIR}", New: tmpDir},
+		Replacement{Old: "$${TEST_TMPDIR}", New: testTmpDir},
 		Replacement{Old: "$${SOCKET_DIR}", New: socketDir},
 	)
 	for label, port := range ports {

--- a/tests/cmdline/BUILD.bazel
+++ b/tests/cmdline/BUILD.bazel
@@ -1,0 +1,51 @@
+load("@rules_itest//:itest.bzl", "itest_task", "service_test")
+
+sh_binary(
+    name = "test_tmpdir_exe",
+    srcs = ["escape_test_tmpdir.sh"],
+    tags = ["manual"],
+)
+
+itest_task(
+    name = "test_tmpdir_exe_task",
+    args = [
+        "$${TEST_TMPDIR}",
+    ],
+    exe = ":test_tmpdir_exe",
+    tags = [
+        "manual",
+        "no-cache",
+    ],
+)
+
+sh_test(
+    name = "noop",
+    srcs = ["noop.sh"],
+    args = [
+        "$${TEST_TMPDIR}",
+    ],
+    tags = [
+        "manual",
+        "no-cache",
+    ],
+)
+
+service_test(
+    name = "test_tmpdir_services",
+    services = [
+        ":test_tmpdir_exe_task",
+    ],
+    tags = ["no-cache"],
+    test = ":noop",
+)
+
+service_test(
+    name = "test_tmpdir_test",
+    args = [
+        # For some reason, the dollar sign need to be escaped when it's passed as an argument.
+        # And rules_itest replaces $${<variables>} with the actual value of the variable.
+        "$$$${TEST_TMPDIR}",
+    ],
+    tags = ["no-cache"],
+    test = ":test_tmpdir_exe",
+)

--- a/tests/cmdline/escape_test_tmpdir.sh
+++ b/tests/cmdline/escape_test_tmpdir.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eux
+
+got="$1"
+
+echo "$got"
+
+# shellcheck disable=SC2016
+if [[ "$got" == \$* ]]; then
+  echo "Received: '$got'"
+  exit 1
+fi;
+

--- a/tests/cmdline/noop.sh
+++ b/tests/cmdline/noop.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "$1"
+
+exit 1

--- a/tests/cmdline/noop.sh
+++ b/tests/cmdline/noop.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
 
-echo "$1"
-
-exit 1
+exit 0

--- a/tests/test_env/BUILD.bazel
+++ b/tests/test_env/BUILD.bazel
@@ -3,6 +3,9 @@ load("@rules_itest//:itest.bzl", "itest_task", "service_test")
 
 env = {
     "ITEST_ENV_VAR": "ITEST_ENV_VAR_VALUE",
+    "ITEST_TEST_TMPDIR": "$${TEST_TMPDIR}",
+    "ITEST_TMPDIR": "$${TMPDIR}",
+    "ITEST_SOCKET_DIR": "$${SOCKET_DIR}",
 }
 
 go_test(

--- a/tests/test_env/env_test.go
+++ b/tests/test_env/env_test.go
@@ -11,15 +11,15 @@ func TestEnv(t *testing.T) {
 	}
 
 	if os.Getenv("ITEST_TEST_TMPDIR") != "$${TEST_TMPDIR}" {
-		t.Fatal("TEST_TMPDIR env var not replaced")
+		t.Fatal("TEST_TMPDIR env var replaced")
 	}
 
 	if os.Getenv("ITEST_TMPDIR") != "$${TMPDIR}" {
-		t.Fatal("TMPDIR env var not replaced")
+		t.Fatal("TMPDIR env var replaced")
 	}
 
 	if os.Getenv("ITEST_SOCKET_DIR") != "$${SOCKET_DIR}" {
-		t.Fatal("SOCKET_DIR env var not replaced")
+		t.Fatal("SOCKET_DIR env var replaced")
 	}
 
 }

--- a/tests/test_env/env_test.go
+++ b/tests/test_env/env_test.go
@@ -10,15 +10,15 @@ func TestEnv(t *testing.T) {
 		t.Fatal("env var not passed")
 	}
 
-	if os.Getenv("ITEST_TEST_TMPDIR") == "$${TEST_TMPDIR}" {
+	if os.Getenv("ITEST_TEST_TMPDIR") != "$${TEST_TMPDIR}" {
 		t.Fatal("TEST_TMPDIR env var not replaced")
 	}
 
-	if os.Getenv("ITEST_TMPDIR") == "$${TMPDIR}" {
+	if os.Getenv("ITEST_TMPDIR") != "$${TMPDIR}" {
 		t.Fatal("TMPDIR env var not replaced")
 	}
 
-	if os.Getenv("ITEST_SOCKET_DIR") == "$${SOCKET_DIR}" {
+	if os.Getenv("ITEST_SOCKET_DIR") != "$${SOCKET_DIR}" {
 		t.Fatal("SOCKET_DIR env var not replaced")
 	}
 

--- a/tests/test_env/env_test.go
+++ b/tests/test_env/env_test.go
@@ -9,4 +9,17 @@ func TestEnv(t *testing.T) {
 	if os.Getenv("ITEST_ENV_VAR") != "ITEST_ENV_VAR_VALUE" {
 		t.Fatal("env var not passed")
 	}
+
+	if os.Getenv("ITEST_TEST_TMPDIR") == "$${TEST_TMPDIR}" {
+		t.Fatal("TEST_TMPDIR env var not replaced")
+	}
+
+	if os.Getenv("ITEST_TMPDIR") == "$${TMPDIR}" {
+		t.Fatal("TMPDIR env var not replaced")
+	}
+
+	if os.Getenv("ITEST_SOCKET_DIR") == "$${SOCKET_DIR}" {
+		t.Fatal("SOCKET_DIR env var not replaced")
+	}
+
 }


### PR DESCRIPTION
This adds a missing replacement for application to be able to use TEST_TMPDIR properly in command args