### PR TITLE
service_test env fails to resolve runfile

### DIFF
--- a/tests/test_env/BUILD.bazel
+++ b/tests/test_env/BUILD.bazel
@@ -3,13 +3,20 @@ load("@rules_itest//:itest.bzl", "itest_task", "service_test")
 
 env = {
     "ITEST_ENV_VAR": "ITEST_ENV_VAR_VALUE",
+    "ENV_RUNFILE": "$(location :test.txt)",
 }
 
 go_test(
     name = "test_env_test",
     srcs = ["env_test.go"],
+    data = [
+        ":test.txt",
+    ],
     env = env,
     tags = ["manual"],
+    deps = [
+        "@rules_go//go/tools/bazel:go_default_library",
+    ],
 )
 
 service_test(
@@ -21,10 +28,16 @@ go_test(
     name = "_env_not_specified",
     srcs = ["env_test.go"],
     tags = ["manual"],
+    deps = [
+        "@rules_go//go/tools/bazel:go_default_library",
+    ],
 )
 
 service_test(
     name = "env_specified_in_service_test",
+    data = [
+        ":test.txt",
+    ],
     env = env,
     test = ":_env_not_specified",
 )

--- a/tests/test_env/env_test.go
+++ b/tests/test_env/env_test.go
@@ -3,10 +3,28 @@ package test_env
 import (
 	"os"
 	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
 )
 
 func TestEnv(t *testing.T) {
 	if os.Getenv("ITEST_ENV_VAR") != "ITEST_ENV_VAR_VALUE" {
 		t.Fatal("env var not passed")
+	}
+}
+
+func TestRLocation(t *testing.T) {
+	filepath, err := bazel.Runfile(os.Getenv("ENV_RUNFILE"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := os.ReadFile(filepath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(content) != "content" {
+		t.Fatal("Content mismatch")
 	}
 }

--- a/tests/test_env/test.txt
+++ b/tests/test_env/test.txt
@@ -1,0 +1,1 @@
+content


### PR DESCRIPTION
Using the `$(location)` resolver on the go_test works fine, but fails when the same is specified on the `service_test`

```
$ bazel test :test_env_test
...
//test_env:test_env_test                                                 PASSED in 0.2s
...
```

```
$ bazel test --test_output streamed :env_specified_in_service_test
...
--- FAIL: TestRLocation (0.00s)
    env_test.go:19: Runfile $(location :test.txt): could not locate file
...
```
