### PR TITLE
Treat 204 as successful itest_service http health check 

### DIFF
--- a/runner/service_instance.go
+++ b/runner/service_instance.go
@@ -132,7 +132,7 @@ func (s *ServiceInstance) HealthCheck(ctx context.Context, expectedStartDuration
 			logFunc("healthcheck for %s failed: %v\n", coloredLabel, err)
 			isHealthy = false
 		} else if resp != nil {
-			if resp.StatusCode != http.StatusOK {
+			if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 				logFunc("healthcheck for %s failed: %v\n", coloredLabel, resp)
 				isHealthy = false
 			}
@@ -216,7 +216,7 @@ func (s *ServiceInstance) Stop(sig syscall.Signal) error {
 	for !s.isDone() {
 		time.Sleep(5 * time.Millisecond)
 	}
-	
+
 	return nil
 }
 


### PR DESCRIPTION
Native `itest_service` HTTP health checking  is extended to recognize 204 as a successful health check response. In addition to responses with 200 status codes, 204 is commonly used for health check protocols since no response body is necessary.