### PR TITLE
Add option for assigning named ports to environment variables

### DIFF
--- a/cmd/svcinit/main.go
+++ b/cmd/svcinit/main.go
@@ -405,6 +405,9 @@ func assignPorts(
 				log.Printf("Assigning port %s to %s\n", port, qualifiedPortName)
 			}
 
+			if spec.NamedPortsInEnv && portName != "" {
+				os.Setenv(fmt.Sprintf("ASSIGNED_PORTS_%s_%s", spec.Name, portName), port)
+			}
 			ports.Set(qualifiedPortName, port)
 
 			if !spec.SoReuseportAware {
@@ -426,7 +429,6 @@ func assignPorts(
 			if portName != "" {
 				qualifiedPortName += ":" + portName
 			}
-
 			ports.Set(qualifiedPortName, ports[aliasedTo])
 		}
 	}

--- a/private/itest.bzl
+++ b/private/itest.bzl
@@ -190,11 +190,13 @@ def _itest_service_impl(ctx):
     shutdown_timeout = ctx.attr.shutdown_timeout or ctx.attr._default_shutdown_timeout[BuildSettingInfo].value
 
     extra_service_spec_kwargs = {
+        "name": ctx.attr.name,
         "type": "service",
         "http_health_check_address": ctx.attr.http_health_check_address,
         "autoassign_port": ctx.attr.autoassign_port,
         "so_reuseport_aware": ctx.attr.so_reuseport_aware,
         "named_ports": ctx.attr.named_ports,
+        "named_ports_in_env": ctx.attr.named_ports_in_env,
         "hot_reloadable": ctx.attr.hot_reloadable,
         "expected_start_duration": ctx.attr.expected_start_duration,
         "health_check_interval": ctx.attr.health_check_interval,
@@ -242,6 +244,11 @@ _itest_service_attrs = _itest_binary_attrs | {
         For example, a port assigned with `named_ports = ["http_port"]` will be assigned a fully-qualified name of `@@//label/for:service:http_port`.
 
         Named ports are accessible through the service-port mapping. For more details, see `autoassign_port`.""",
+    ),
+    "named_ports_in_env": attr.bool(
+        doc = """If set, each named port will also be assigned to a environment variable. The format for the environment
+        variable name is ASSIGNED_PORTS_<SERVICE>_<PORT NAME>. The value will be the automatially assigned port. This is
+        designed to make it easier to interpolate assigned ports into third party services."""
     ),
     "so_reuseport_aware": attr.bool(
         doc = """If set, the service manager will not release the autoassigned port. The service binary must use SO_REUSEPORT when binding it.

--- a/svclib/types.go
+++ b/svclib/types.go
@@ -6,6 +6,7 @@ import "rules_itest/logger"
 type ServiceSpec struct {
 	// Type can be "service", "task", or "group".
 	Type                    string            `json:"type"`
+	Name                    string            `json:"name"`
 	Label                   string            `json:"label"`
 	Args                    []string          `json:"args"`
 	Env                     map[string]string `json:"env"`
@@ -22,6 +23,7 @@ type ServiceSpec struct {
 	AutoassignPort          bool              `json:"autoassign_port"`
 	SoReuseportAware        bool              `json:"so_reuseport_aware"`
 	NamedPorts              []string          `json:"named_ports"`
+	NamedPortsInEnv         bool              `json:"named_ports_in_env"`
 	HotReloadable           bool              `json:"hot_reloadable"`
 	PortAliases             map[string]string `json:"port_aliases"`
 	ShutdownSignal          string            `json:"shutdown_signal"`

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -90,6 +90,7 @@ itest_service(
     autoassign_port = True,
     exe = "//go_service",
     http_health_check_address = "http://127.0.0.1:$${@@//:named_port:http_port}",
+    named_ports_in_env = True,
     named_ports = ["http_port"],
 )
 

--- a/tests/go_service/main.go
+++ b/tests/go_service/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/bazelbuild/rules_go/go/runfiles"
@@ -30,6 +32,11 @@ func main() {
 		}()
 	}
 
+	for _, ev := range os.Environ() {
+		if strings.HasPrefix(ev, "ASSIGNED_PORTS_") {
+			fmt.Println(ev)
+		}
+	}
 	if *port == "" {
 		portStr := os.Getenv("PORT")
 		port = &portStr


### PR DESCRIPTION
This allows for developers to opt in to a purely env based way to propagate port assignments. I've got a use case where a third party service only supports configuring the health check endpoint via its config file, which supports env variable interpolation.
A somewhat niche usecase, but its easier than making a wrapper script.

This PR adds a new option on itest_service, `named_ports_in_env`, that lets the user opt in to this new behavior. When enabled each named ports is assigned to an environment variable `ASSIGNED_PORTS_${service}_${port_name}`.

lmk if this is something you'd be open to adding and I'll clean it up and add more docs.