### PR TITLE
feat: add convenience macros for creating port/named_port strings

### DIFF
--- a/itest.bzl
+++ b/itest.bzl
@@ -8,6 +8,12 @@ load(
     _service_test = "service_test",
 )
 
+def port(label):
+    return "$${%s}" % (str(native.package_relative_label(label)))
+
+def named_port(label, name):
+    return "$${%s:%s}" % (str(native.package_relative_label(label)), name)
+
 def itest_service(name, tags = [], hygienic = True, **kwargs):
     _itest_service(
         name = name,

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@gazelle//:def.bzl", "gazelle")
-load("@rules_itest//:itest.bzl", "itest_service", "itest_service_group")
+load("@rules_itest//:itest.bzl", "itest_service", "itest_service_group", "named_port", "port")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -85,7 +85,7 @@ itest_service(
     name = "named_port",
     args = [
         "-port",
-        "$${@@//:named_port:http_port}",
+        named_port(":named_port", "http_port")
     ],
     autoassign_port = True,
     exe = "//go_service",
@@ -107,7 +107,7 @@ itest_service(
     name = "autoassigned_env2",
     autoassign_port = True,
     env = {
-        "PORT": "$${@@//:autoassigned_env2}",
+        "PORT": port(":autoassigned_env2"),
     },
     exe = "//go_service",
     http_health_check_address = "http://127.0.0.1:$${PORT}",
@@ -118,7 +118,7 @@ itest_service(
     name = "_speedy_service2",
     args = [
         "-port",
-        "$${@@//:speedy_service2}",
+        port(":speedy_service2"),
     ],
     autoassign_port = True,
     env = {"foo": "bar"},


### PR DESCRIPTION
This PR adds a couple of convenience macros for constructing port strings of the form `$${@@//:auto_assigned_port}` and `$${@@//:named_port:port_name}`. In particular, it makes it simpler to use relative labels when itest_services are defined in the same Bazel package as their tests.

I've updated a few tests to document usage.

I've added these to the root `itest.bzl`, but let me know if these belong better in a different file.