### PR TITLE
Support port substitution in service_test args

### DIFF
--- a/cmd/svcinit/main.go
+++ b/cmd/svcinit/main.go
@@ -193,7 +193,24 @@ func main() {
 		testCtx, testCancel := context.WithCancel(ctx)
 		testErrCh := make(chan error, 1)
 		if testLabel != "" {
-			testArgs := os.Args[1:]
+			// Bazel's args attribute converts $$ to $, so args arrive with
+			// single-$ placeholders (e.g. ${@@//:svc}) unlike env/spec files
+			// which preserve the literal $$ since they're read from JSON.
+			argReplacements := make([]Replacement, 0, 2+len(ports))
+			argReplacements = append(argReplacements,
+				Replacement{Old: "${TMPDIR}", New: os.Getenv("TMPDIR")},
+				Replacement{Old: "${SOCKET_DIR}", New: os.Getenv("SOCKET_DIR")},
+			)
+			for label, port := range ports {
+				argReplacements = append(argReplacements, Replacement{
+					Old: "${" + label + "}",
+					New: port,
+				})
+			}
+			testArgs := make([]string, len(os.Args[1:]))
+			for i, arg := range os.Args[1:] {
+				testArgs[i] = replaceAll(arg, argReplacements)
+			}
 			testPath, err := runfiles.Rlocation(os.Getenv("SVCINIT_TEST_RLOCATION_PATH"))
 			must(err)
 
@@ -577,6 +594,28 @@ type Replacement struct {
 	New string
 }
 
+func buildReplacements(ports svclib.Ports) []Replacement {
+	replacements := make([]Replacement, 0, 2+len(ports))
+	replacements = append(replacements,
+		Replacement{Old: "$${TMPDIR}", New: os.Getenv("TMPDIR")},
+		Replacement{Old: "$${SOCKET_DIR}", New: os.Getenv("SOCKET_DIR")},
+	)
+	for label, port := range ports {
+		replacements = append(replacements, Replacement{
+			Old: "$${" + label + "}",
+			New: port,
+		})
+	}
+	return replacements
+}
+
+func replaceAll(s string, replacements []Replacement) string {
+	for _, r := range replacements {
+		s = strings.ReplaceAll(s, r.Old, r.New)
+	}
+	return s
+}
+
 func buildTestEnv(ports svclib.Ports) ([]string, error) {
 	testEnvPath, err := runfiles.Rlocation(os.Getenv("SVCINIT_TEST_ENV_RLOCATION_PATH"))
 	if err != nil {
@@ -594,34 +633,15 @@ func buildTestEnv(ports svclib.Ports) ([]string, error) {
 		panic(err)
 	}
 
-	tmpDir := os.Getenv("TMPDIR")
-	socketDir := os.Getenv("SOCKET_DIR")
-
-	replacements := make([]Replacement, 0, 2+len(ports))
-	replacements = append(replacements,
-		Replacement{Old: "$${TMPDIR}", New: tmpDir},
-		Replacement{Old: "$${SOCKET_DIR}", New: socketDir},
-	)
-	for label, port := range ports {
-		replacements = append(replacements, Replacement{
-			Old: "$${" + label + "}",
-			New: port,
-		})
-	}
-
-	replaceAllPorts := func(s string) string {
-		for _, r := range replacements {
-			s = strings.ReplaceAll(s, r.Old, r.New)
-		}
-		return s
-	}
+	replacements := buildReplacements(ports)
 
 	// Note, this can technically specify the same var multiple times.
 	// Last one wins - hope that's what you wanted!
 	baseEnv := os.Environ()
 	for k, v := range env {
-		baseEnv = append(baseEnv, k+"="+replaceAllPorts(v))
+		baseEnv = append(baseEnv, k+"="+replaceAll(v, replacements))
 	}
 
 	return baseEnv, nil
 }
+

--- a/cmd/svcinit/main.go
+++ b/cmd/svcinit/main.go
@@ -196,17 +196,7 @@ func main() {
 			// Bazel's args attribute converts $$ to $, so args arrive with
 			// single-$ placeholders (e.g. ${@@//:svc}) unlike env/spec files
 			// which preserve the literal $$ since they're read from JSON.
-			argReplacements := make([]Replacement, 0, 2+len(ports))
-			argReplacements = append(argReplacements,
-				Replacement{Old: "${TMPDIR}", New: os.Getenv("TMPDIR")},
-				Replacement{Old: "${SOCKET_DIR}", New: os.Getenv("SOCKET_DIR")},
-			)
-			for label, port := range ports {
-				argReplacements = append(argReplacements, Replacement{
-					Old: "${" + label + "}",
-					New: port,
-				})
-			}
+			argReplacements := buildReplacements(ports, "${")
 			testArgs := make([]string, len(os.Args[1:]))
 			for i, arg := range os.Args[1:] {
 				testArgs[i] = replaceAll(arg, argReplacements)
@@ -594,15 +584,18 @@ type Replacement struct {
 	New string
 }
 
-func buildReplacements(ports svclib.Ports) []Replacement {
+// buildReplacements creates port/env substitution pairs.
+// prefix is "$${" for values from JSON files (which preserve literal $$),
+// or "${" for values from Bazel args (where $$ is already collapsed to $).
+func buildReplacements(ports svclib.Ports, prefix string) []Replacement {
 	replacements := make([]Replacement, 0, 2+len(ports))
 	replacements = append(replacements,
-		Replacement{Old: "$${TMPDIR}", New: os.Getenv("TMPDIR")},
-		Replacement{Old: "$${SOCKET_DIR}", New: os.Getenv("SOCKET_DIR")},
+		Replacement{Old: prefix + "TMPDIR}", New: os.Getenv("TMPDIR")},
+		Replacement{Old: prefix + "SOCKET_DIR}", New: os.Getenv("SOCKET_DIR")},
 	)
 	for label, port := range ports {
 		replacements = append(replacements, Replacement{
-			Old: "$${" + label + "}",
+			Old: prefix + label + "}",
 			New: port,
 		})
 	}
@@ -633,7 +626,7 @@ func buildTestEnv(ports svclib.Ports) ([]string, error) {
 		panic(err)
 	}
 
-	replacements := buildReplacements(ports)
+	replacements := buildReplacements(ports, "$${")
 
 	// Note, this can technically specify the same var multiple times.
 	// Last one wins - hope that's what you wanted!

--- a/tests/test_args/BUILD.bazel
+++ b/tests/test_args/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_test")
+load("@rules_itest//:itest.bzl", "service_test")
+
+go_test(
+    name = "_args_test",
+    srcs = ["args_test.go"],
+    tags = ["manual"],
+)
+
+service_test(
+    name = "args_test",
+    services = ["//:autoassigned"],
+    test = ":_args_test",
+    args = [
+        "--test-arg=hello",
+        "--test-port=$${@@//:autoassigned}",
+    ],
+)

--- a/tests/test_args/args_test.go
+++ b/tests/test_args/args_test.go
@@ -1,0 +1,25 @@
+package test_args
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+var (
+	testArg  = flag.String("test-arg", "", "a literal test argument")
+	testPort = flag.String("test-port", "", "a port-substituted test argument")
+)
+
+func TestArgs(t *testing.T) {
+	if *testArg != "hello" {
+		t.Fatalf("expected test-arg=hello, got: %q (os.Args: %v)", *testArg, os.Args)
+	}
+}
+
+func TestPortArg(t *testing.T) {
+	port := *testPort
+	if port == "" || port[0] == '$' {
+		t.Fatalf("port was not substituted, got: %q (os.Args: %v)", *testPort, os.Args)
+	}
+}


### PR DESCRIPTION
Doesn't quite solve https://github.com/dzbarsky/rules_itest/issues/54, but at least makes it so we can use args with port value replacement