### PR TITLE
Add new functions to compute the right labels for aliases in itest_service_group

### DIFF
--- a/examples/dynamodb/BUILD.bazel
+++ b/examples/dynamodb/BUILD.bazel
@@ -48,6 +48,7 @@ itest_service(
     autoassign_port = True,
     exe = ":bin",
     health_check = ":health_check",
+    visibility = ["//visibility:public"],
 )
 
 go_library(

--- a/examples/redis/BUILD.bazel
+++ b/examples/redis/BUILD.bazel
@@ -4,19 +4,21 @@ itest_service(
     name = "redis",
     args = [
         "--port",
-        "0",
-        "--unixsocket",
-        "$${TMPDIR}/redis.sock",
-        "--unixsocketperm",
-        "770",
+        "$${PORT}",
         "--dir",
         "$${TMPDIR}",
     ],
+    autoassign_port = True,
     exe = "@com_github_redis_redis//:redis",
     health_check = "@com_github_redis_redis//:redis_cli",
     health_check_args = [
-        "-s",
-        "$${TMPDIR}/redis.sock",
+        "-h",
+        "localhost",
+        "-p",
+        "$${PORT}",
         "PING",
+    ],
+    tags = [
+        "requires-network",
     ],
 )

--- a/examples/redis/BUILD.bazel
+++ b/examples/redis/BUILD.bazel
@@ -4,6 +4,27 @@ itest_service(
     name = "redis",
     args = [
         "--port",
+        "0",
+        "--unixsocket",
+        "$${TMPDIR}/redis.sock",
+        "--unixsocketperm",
+        "770",
+        "--dir",
+        "$${TMPDIR}",
+    ],
+    exe = "@com_github_redis_redis//:redis",
+    health_check = "@com_github_redis_redis//:redis_cli",
+    health_check_args = [
+        "-s",
+        "$${TMPDIR}/redis.sock",
+        "PING",
+    ],
+)
+
+itest_service(
+    name = "redis_network",
+    args = [
+        "--port",
         "$${PORT}",
         "--dir",
         "$${TMPDIR}",
@@ -21,4 +42,5 @@ itest_service(
     tags = [
         "requires-network",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/examples/service_group/BUILD.bazel
+++ b/examples/service_group/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_itest//:itest.bzl", "itest_service_group", "port_alias")
+
+itest_service_group(
+    name = "group",
+    port_aliases = {
+        "dynamodb": port_alias("//dynamodb"),
+        "mysql": port_alias("//mysql:mysql_listening_on_port"),
+        "redis": port_alias("//redis:redis_network"),
+    },
+    services = [
+        "//dynamodb:dynamodb",
+        "//mysql:mysql_listening_on_port",
+        "//redis:redis_network",
+    ],
+)

--- a/examples/service_group/BUILD.bazel
+++ b/examples/service_group/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_itest//:itest.bzl", "itest_service_group", "port_alias")
 
 itest_service_group(
-    name = "group",
+    name = "service_group",
     port_aliases = {
         "dynamodb": port_alias("//dynamodb"),
         "mysql": port_alias("//mysql:mysql_listening_on_port"),

--- a/itest.bzl
+++ b/itest.bzl
@@ -9,11 +9,39 @@ load(
     _service_test = "service_test",
 )
 
+def _to_relative_port(label):
+    return str(native.package_relative_label(label))
+
+def _to_relative_named_port(label, name):
+    return _to_relative_port(label + "." + name)
+
 def port(label):
-    return "$${%s}" % (str(native.package_relative_label(label)))
+    """This function is used to reference the auto assigned port of a service in the `args` or `env` attributes of an `itest_service` or `itest_task`.
+
+    To reference the auto assigned port in the `itest_service_group` use `port_alias` instead
+    """
+    return "$${%s}" % _to_relative_port(label)
 
 def named_port(label, name):
-    return port(label + "." + name)
+    """This function is used to reference a named port of a service in the `args` or `env` attributes of an `itest_service` or `itest_task`.
+
+    To reference a named port in the `itest_service_group` use `named_port_alias` instead
+    """
+    return port(_to_relative_named_port(label, name))
+
+def port_alias(label):
+    """This function is used to reference the auto assigned port of a service in the `aliases` attribute of an `itest_service_group`.
+
+    To reference the auto assigned port in `itest_service` or `itest_task` use `port` instead
+    """
+    return _to_relative_port(label)
+
+def named_port_alias(label, name):
+    """This function is used to reference a named port of a service in the `aliases` attribute of an `itest_service_group`.
+
+    To reference a named port in `itest_service` or `itest_task` use `named_port` instead
+    """
+    return _to_relative_named_port(label, name)
 
 def itest_service(name, tags = [], hygienic = True, named_ports = [], **kwargs):
     if "port" in kwargs:

--- a/private/itest.bzl
+++ b/private/itest.bzl
@@ -253,7 +253,7 @@ _itest_service_attrs = _itest_binary_attrs | {
         For example, the following Bash command:
         `PORT=$($GET_ASSIGNED_PORT_BIN @@//label/for:service)`""",
     ),
-    "port": attr.label(doc="Internal"),
+    "port": attr.label(doc = "Internal"),
     "named_ports": attr.label_keyed_string_dict(
         doc = """For each element of the list, the service manager will pick a free port and assign it to the service.
         The port's fully-qualified name is the service's fully-qualified label and the port name, separated by a colon.
@@ -375,7 +375,9 @@ _itest_service_group_attrs = _svcinit_attrs | {
     "port_aliases": attr.string_dict(
         doc = """Port aliases allow you to 're-export' another service's port as belonging to this service group.
 This can be used to create abstractions (such as an itest_service combined with an itest_task) but not leak
-their implementation through how client code accesses port names.""",
+their implementation naming details through how client code accesses port names.
+
+Use the functions `port_alias` and `named_port_alias` to reference ports from the services to alias ports for""",
     ),
     "services": attr.label_list(
         providers = [_ServiceGroupInfo],


### PR DESCRIPTION
Also migrated the redis example to use a port instead of domain socket to have a real usage example for $${PORT}