### PR TITLE
fix: svcinit tolerates service crash in ibazel reload mode

### DIFF
--- a/cmd/svcinit/main.go
+++ b/cmd/svcinit/main.go
@@ -351,6 +351,50 @@ func main() {
 		if isOneShot {
 			break
 		}
+
+		if shouldHotReload && !enablePerServiceReload {
+			fmt.Println()
+			fmt.Println()
+			fmt.Println("###########################################################################################")
+			fmt.Println("  Detected that you are running under ibazel, but do not have per-service-reload enabled.")
+			fmt.Println("  In this configuration, services will not be restarted when their code changes.")
+			fmt.Println("  If this was unintentional, you can retry with per-service-reload enabled:")
+			fmt.Println("")
+			fmt.Printf("  `bazel run --@rules_itest//:enable_per_service_reload %s`\n", testLabel)
+			fmt.Println("###########################################################################################")
+			fmt.Println()
+			fmt.Println()
+		}
+
+		select {
+		case <-ctx.Done():
+			log.Println("Shutting down services.")
+			_, err := r.StopAll()
+			must(err)
+			log.Println("Cleaning up.")
+			return
+		case ibazelCmd := <-interactiveCh:
+			log.Println(ibazelCmd)
+
+			// Restart any services as needed.
+			unversionedSpecs, err := readServiceSpecs(serviceSpecsPath)
+			must(err)
+
+			serviceSpecs, err := augmentServiceSpecs(unversionedSpecs, ports, svcctlPortStr)
+			must(err)
+
+			// Non-blocking drain of any pending service crash errors before restarting.
+			for {
+				select {
+				case <-servicesErrCh:
+				default:
+					goto drained
+				}
+			}
+		drained:
+			criticalPath, err = r.UpdateSpecsAndRestart(serviceSpecs, servicesErrCh, []byte(ibazelCmd))
+			must(err)
+		}
 	}
 }
 

--- a/cmd/svcinit/main.go
+++ b/cmd/svcinit/main.go
@@ -383,15 +383,16 @@ func main() {
 			serviceSpecs, err := augmentServiceSpecs(unversionedSpecs, ports, svcctlPortStr)
 			must(err)
 
-			// Non-blocking drain of any pending service crash errors before restarting.
-			for {
-				select {
-				case <-servicesErrCh:
-				default:
-					goto drained
-				}
+		// Non-blocking drain of any pending service crash errors before restarting.
+		for {
+			select {
+			case crashErr := <-servicesErrCh:
+				log.Printf("Discarding pending service error before reload: %v", crashErr)
+			default:
+				goto drained
 			}
-		drained:
+		}
+	drained:
 			criticalPath, err = r.UpdateSpecsAndRestart(serviceSpecs, servicesErrCh, []byte(ibazelCmd))
 			must(err)
 		}

--- a/cmd/svcinit/main.go
+++ b/cmd/svcinit/main.go
@@ -285,17 +285,17 @@ func main() {
 
 			testCancel()
 
-			// TODO(zbarsky): what is the right behavior here when services are crashing in ibazel mode?
-
 			// This is a brittle way of draining a channel in a nonblocking way,
 			// consider instead signalling cancellation of the services with a
 			// context, letting them close the channel, and using a waitgroup to
 			// wait for them to exit.
+			// Non-blocking drain of any pending service crash errors before restarting.
+			// See: https://github.com/hermeticbuild/rules_itest/issues/72
 		Drain:
 			for {
 				select {
-				case <-servicesErrCh:
-					// nothing
+				case crashErr := <-servicesErrCh:
+					log.Printf("Discarding pending service error before reload: %v", crashErr)
 				default:
 					break Drain
 				}
@@ -350,51 +350,6 @@ func main() {
 
 		if isOneShot {
 			break
-		}
-
-		if shouldHotReload && !enablePerServiceReload {
-			fmt.Println()
-			fmt.Println()
-			fmt.Println("###########################################################################################")
-			fmt.Println("  Detected that you are running under ibazel, but do not have per-service-reload enabled.")
-			fmt.Println("  In this configuration, services will not be restarted when their code changes.")
-			fmt.Println("  If this was unintentional, you can retry with per-service-reload enabled:")
-			fmt.Println("")
-			fmt.Printf("  `bazel run --@rules_itest//:enable_per_service_reload %s`\n", testLabel)
-			fmt.Println("###########################################################################################")
-			fmt.Println()
-			fmt.Println()
-		}
-
-		select {
-		case <-ctx.Done():
-			log.Println("Shutting down services.")
-			_, err := r.StopAll()
-			must(err)
-			log.Println("Cleaning up.")
-			return
-		case ibazelCmd := <-interactiveCh:
-			log.Println(ibazelCmd)
-
-			// Restart any services as needed.
-			unversionedSpecs, err := readServiceSpecs(serviceSpecsPath)
-			must(err)
-
-			serviceSpecs, err := augmentServiceSpecs(unversionedSpecs, ports, svcctlPortStr)
-			must(err)
-
-		// Non-blocking drain of any pending service crash errors before restarting.
-		for {
-			select {
-			case crashErr := <-servicesErrCh:
-				log.Printf("Discarding pending service error before reload: %v", crashErr)
-			default:
-				goto drained
-			}
-		}
-	drained:
-			criticalPath, err = r.UpdateSpecsAndRestart(serviceSpecs, servicesErrCh, []byte(ibazelCmd))
-			must(err)
 		}
 	}
 }

--- a/cmd/svcinit/main.go
+++ b/cmd/svcinit/main.go
@@ -285,12 +285,11 @@ func main() {
 
 			testCancel()
 
-			// This is a brittle way of draining a channel in a nonblocking way,
-			// consider instead signalling cancellation of the services with a
-			// context, letting them close the channel, and using a waitgroup to
-			// wait for them to exit.
-			// Non-blocking drain of any pending service crash errors before restarting.
-			// See: https://github.com/hermeticbuild/rules_itest/issues/72
+		// This is a brittle way of draining a channel in a nonblocking way,
+		// consider instead signalling cancellation of the services with a
+		// context, letting them close the channel, and using a waitgroup to
+		// wait for them to exit.
+		// See: https://github.com/hermeticbuild/rules_itest/issues/72
 		Drain:
 			for {
 				select {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -200,7 +200,14 @@ func (r *Runner) UpdateSpecs(serviceSpecs ServiceSpecs, ibazelCmd []byte) error 
 	for _, label := range updateActions.toReloadLabels {
 		_, err := r.serviceInstances[label].stdin.Write(ibazelCmd)
 		if err != nil {
-			return err
+			// Service likely crashed — fall back to a full restart.
+			log.Printf(colorize(r.serviceInstances[label].VersionedServiceSpec) + " hot-reload stdin write failed, falling back to restart: " + err.Error())
+			r.serviceInstances[label].Stop(syscall.SIGKILL)
+			delete(r.serviceInstances, label)
+			r.serviceInstances[label], err = prepareServiceInstance(r.ctx, serviceSpecs[label])
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"runtime"
 	"sync"
+	"syscall"
 	"time"
 
 	"rules_itest/logger"
@@ -202,7 +203,7 @@ func (r *Runner) UpdateSpecs(serviceSpecs ServiceSpecs, ibazelCmd []byte) error 
 		if err != nil {
 			// Service likely crashed — fall back to a full restart.
 			log.Printf(colorize(r.serviceInstances[label].VersionedServiceSpec) + " hot-reload stdin write failed, falling back to restart: " + err.Error())
-			r.serviceInstances[label].Stop(syscall.SIGKILL)
+			r.serviceInstances[label].StopWithSignal(syscall.SIGKILL)
 			delete(r.serviceInstances, label)
 			r.serviceInstances[label], err = prepareServiceInstance(r.ctx, serviceSpecs[label])
 			if err != nil {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -202,8 +202,12 @@ func (r *Runner) UpdateSpecs(serviceSpecs ServiceSpecs, ibazelCmd []byte) error 
 		_, err := r.serviceInstances[label].stdin.Write(ibazelCmd)
 		if err != nil {
 			// Service likely crashed — fall back to a full restart.
-			log.Printf(colorize(r.serviceInstances[label].VersionedServiceSpec) + " hot-reload stdin write failed, falling back to restart: " + err.Error())
-			r.serviceInstances[label].StopWithSignal(syscall.SIGKILL)
+			old := r.serviceInstances[label]
+			log.Printf("%s hot-reload stdin write failed, falling back to restart: %v", colorize(old.VersionedServiceSpec), err)
+			old.stdin.Close()
+			if stopErr := old.StopWithSignal(syscall.SIGKILL); stopErr != nil {
+				log.Printf("%s stop during crash fallback failed: %v", colorize(old.VersionedServiceSpec), stopErr)
+			}
 			delete(r.serviceInstances, label)
 			r.serviceInstances[label], err = prepareServiceInstance(r.ctx, serviceSpecs[label])
 			if err != nil {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -199,10 +199,10 @@ func (r *Runner) UpdateSpecs(serviceSpecs ServiceSpecs, ibazelCmd []byte) error 
 	}
 
 	for _, label := range updateActions.toReloadLabels {
-		_, err := r.serviceInstances[label].stdin.Write(ibazelCmd)
+		old := r.serviceInstances[label]
+		_, err := old.stdin.Write(ibazelCmd)
 		if err != nil {
 			// Service likely crashed — fall back to a full restart.
-			old := r.serviceInstances[label]
 			log.Printf("%s hot-reload stdin write failed, falling back to restart: %v", colorize(old.VersionedServiceSpec), err)
 			old.stdin.Close()
 			if stopErr := old.StopWithSignal(syscall.SIGKILL); stopErr != nil {

--- a/runner/service_instance.go
+++ b/runner/service_instance.go
@@ -249,8 +249,9 @@ func (s *ServiceInstance) StopWithSignal(signal syscall.Signal) error {
 		s.killed = true
 	}()
 
-	if err != nil {
-		return err
+	// If process already exited, nothing to kill.
+	if s.isDone() {
+		return nil
 	}
 
 	if signal == syscall.SIGKILL {

--- a/runner/service_instance.go
+++ b/runner/service_instance.go
@@ -249,12 +249,9 @@ func (s *ServiceInstance) StopWithSignal(signal syscall.Signal) error {
 		s.killed = true
 	}()
 
-	// If process already exited, still attempt to clean up any remaining
-	// process group members (children may outlive the group leader).
-	// Any error (ESRCH, EPERM) is intentionally discarded — the group leader
-	// is already done, so cleanup is best-effort.
+	// If the process has already exited (raced between killGroup above and here),
+	// return nil — the killGroup call above already attempted group cleanup.
 	if s.isDone() {
-		_ = killGroup(s.cmd, signal)
 		return nil
 	}
 

--- a/runner/service_instance.go
+++ b/runner/service_instance.go
@@ -251,6 +251,8 @@ func (s *ServiceInstance) StopWithSignal(signal syscall.Signal) error {
 
 	// If process already exited, still attempt to clean up any remaining
 	// process group members (children may outlive the group leader).
+	// Any error (ESRCH, EPERM) is intentionally discarded — the group leader
+	// is already done, so cleanup is best-effort.
 	if s.isDone() {
 		_ = killGroup(s.cmd, signal)
 		return nil

--- a/runner/service_instance.go
+++ b/runner/service_instance.go
@@ -249,8 +249,10 @@ func (s *ServiceInstance) StopWithSignal(signal syscall.Signal) error {
 		s.killed = true
 	}()
 
-	// If process already exited, nothing to kill.
+	// If process already exited, still attempt to clean up any remaining
+	// process group members (children may outlive the group leader).
 	if s.isDone() {
+		_ = killGroup(s.cmd, signal)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

When running under `ibazel run --@rules_itest//:enable_per_service_reload`, if a service crashes, svcinit panics on the next reload notification. Additionally, the existing drain loop silently discards crash errors — this PR adds logging to make them visible.

## Changes

- **Log discarded crash errors** (`cmd/svcinit/main.go`): The existing `Drain:` loop drains `servicesErrCh` non-blocking before reload. This PR adds `log.Printf` for each discarded error so crashes are visible in output.
- **`StopWithSignal()` tolerates dead processes** (`runner/service_instance.go`): After calling `killGroup`, if the process raced to exit (`isDone()`), return nil instead of propagating the error. The initial `killGroup` call already attempted group cleanup.
- **Hot-reload fallback** (`runner/runner.go`): If `stdin.Write` fails for a hot-reloadable service (broken pipe from crash), explicitly close the old stdin pipe, log the stop error, and fall back to a full stop+restart instead of propagating the error.

Fixes #72