### PR TITLE
Fix service process state data race

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -284,7 +284,7 @@ func initializeServiceCmd(ctx context.Context, instance *ServiceInstance) error 
 	instance.startErrFn = sync.OnceValue(cmd.Start)
 	instance.waitErrFn = sync.OnceValue(func() error {
 		res := cmd.Wait()
-		instance.SetDone()
+		instance.setProcessState(cmd.ProcessState)
 		return res
 	})
 
@@ -298,6 +298,7 @@ func initializeServiceCmd(ctx context.Context, instance *ServiceInstance) error 
 
 	instance.mu.Lock()
 	instance.runErr = nil
+	instance.processState = nil
 	instance.done = false
 	instance.healthcheckAttempted = false
 	instance.mu.Unlock()

--- a/runner/service_instance.go
+++ b/runner/service_instance.go
@@ -31,6 +31,7 @@ type ServiceInstance struct {
 
 	mu                   sync.Mutex
 	runErr               error
+	processState         *os.ProcessState
 	killed               bool
 	healthcheckAttempted bool
 	done                 bool
@@ -87,7 +88,7 @@ func (s *ServiceInstance) WaitUntilHealthy(ctx context.Context) error {
 		}
 
 		if s.isDone() {
-			state := s.cmd.ProcessState
+			state := s.ProcessState()
 			if state != nil {
 				return fmt.Errorf("%s exited before becoming healthy: %s", coloredLabel, state.String())
 			}
@@ -323,7 +324,9 @@ func (s *ServiceInstance) Pid() int {
 }
 
 func (s *ServiceInstance) ProcessState() *os.ProcessState {
-	return s.cmd.ProcessState
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.processState
 }
 
 // Returns true if killed by svcinit / svcctl instead of exited normally or crashed.
@@ -336,7 +339,7 @@ func (s *ServiceInstance) Killed() bool {
 func (s *ServiceInstance) isDone() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.done && s.cmd.ProcessState != nil
+	return s.done && s.processState != nil
 }
 
 func (s *ServiceInstance) isRunning() bool {
@@ -351,5 +354,12 @@ func (s *ServiceInstance) isRunning() bool {
 func (s *ServiceInstance) SetDone() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.done = true
+}
+
+func (s *ServiceInstance) setProcessState(state *os.ProcessState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processState = state
 	s.done = true
 }

--- a/tests/process_state_race/BUILD.bazel
+++ b/tests/process_state_race/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "process_state_race_test",
+    srcs = ["process_state_race_test.go"],
+    gc_linkopts = [
+        "-extldflags",
+        "-no-pie",
+    ],
+    pure = "off",
+    race = "on",
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = ["@rules_itest//runner"],
+)

--- a/tests/process_state_race/process_state_race_test.go
+++ b/tests/process_state_race/process_state_race_test.go
@@ -1,0 +1,64 @@
+package process_state_race_test
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"rules_itest/runner"
+)
+
+func TestProcessStateAccessIsSynchronized(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	instance := &runner.ServiceInstance{}
+	instance.Type = "service"
+	instance.Label = "process-state-race-helper"
+	instance.Exe = exe
+	instance.Args = []string{"-test.run=^TestProcessStateRaceHelper$"}
+	instance.Env = map[string]string{"GO_WANT_PROCESS_STATE_RACE_HELPER": "1"}
+
+	if err := instance.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	readerStarted := make(chan struct{})
+	stopReader := make(chan struct{})
+	readerDone := make(chan struct{})
+	go func() {
+		close(readerStarted)
+		defer close(readerDone)
+		for {
+			select {
+			case <-stopReader:
+				return
+			default:
+				_ = instance.ProcessState()
+				runtime.Gosched()
+			}
+		}
+	}()
+
+	<-readerStarted
+	if err := instance.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	close(stopReader)
+	<-readerDone
+
+	if state := instance.ProcessState(); state == nil {
+		t.Fatal("process state is nil after Wait")
+	}
+}
+
+func TestProcessStateRaceHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_PROCESS_STATE_RACE_HELPER") != "1" {
+		return
+	}
+	time.Sleep(10 * time.Millisecond)
+}


### PR DESCRIPTION
## Summary

- snapshot `exec.Cmd.ProcessState` under `ServiceInstance`'s existing mutex after `Cmd.Wait` completes
- route service process-state reads through the synchronized snapshot
- add a Linux race-detector regression test in the existing `tests` workspace

## Why

`Cmd.Wait` writes `Cmd.ProcessState` while `Runner.StopAll` and health checks may read it concurrently. The Go race detector reports that unsynchronized access in #71.

The snapshot preserves the existing `ProcessState()` API and is reset when a service command is reinitialized.

## Regression test

The test uses target-local `-no-pie` because rules_go race mode requires external linking and the registered hermetic LLVM toolchain hits [golang/go#76825](https://github.com/golang/go/issues/76825): the linker probe drops required hermetic flags, misses `-no-pie`, and then rejects Go's position-dependent objects under PIE semantics. This flag affects only the Linux race-regression target.

## Validation

- before the fix, the focused test reproduced the `Cmd.Wait` / `ProcessState()` race under `go test -race`
- `GOWORK=/tmp/rules-itest-issue71-go.work go test -race -vet=off ./process_state_race -run '^TestProcessStateAccessIsSynchronized$' -count=1`
- `bazel build //runner/...`
- [exact-head full workflow run](https://github.com/yaroslavvoloshchuk-codaio/rules_itest/actions/runs/29704277275) at `557bbc529ee1ab166322bd7990a5c4f73cad2cd4`
  - [Ubuntu](https://github.com/yaroslavvoloshchuk-codaio/rules_itest/actions/runs/29704277275/job/88238509082): 43/43 tests passed; the new race target passed in 3.0s
  - [Windows](https://github.com/yaroslavvoloshchuk-codaio/rules_itest/actions/runs/29704277275/job/88238509049): 37 tests passed and six platform-incompatible tests, including the Linux-only race target, were skipped

Fixes #71.
