### PR TITLE
Fix deferred service dependency health check

### DIFF
--- a/svcctl/svcctl.go
+++ b/svcctl/svcctl.go
@@ -84,9 +84,10 @@ func handleStart(ctx context.Context, r *runner.Runner, serviceErrCh chan error,
 				continue
 			}
 
-			depsErr := s.WaitUntilHealthy(ctx)
+			depsErr := depService.WaitUntilHealthy(ctx)
 			if depsErr != nil {
 				http.Error(w, fmt.Sprintf("Failed to wait for %q until healthy", dep), http.StatusInternalServerError)
+				return
 			}
 		}
 	}

--- a/tests/deferred/BUILD.bazel
+++ b/tests/deferred/BUILD.bazel
@@ -38,6 +38,18 @@ itest_service(
     ],
     autoassign_port = True,
     deferred = True,
+    deps = [":non_deferred_itest_service"],
+    exe = ":deferred",
+    http_health_check_address = "http://localhost:$${PORT}/healthz",
+    tags = ["requires-network"],
+)
+
+itest_service(
+    name = "non_deferred_itest_service",
+    args = [
+        "$${PORT}",
+    ],
+    autoassign_port = True,
     exe = ":deferred",
     http_health_check_address = "http://localhost:$${PORT}/healthz",
     tags = ["requires-network"],


### PR DESCRIPTION
## Summary

- wait for the actual non-deferred dependency when starting a deferred service
- stop handling the start request after a dependency health-check failure
- cover the behavior with a deferred service that depends on a healthy non-deferred service

## Root cause

`handleStart` iterated over dependency labels but called `WaitUntilHealthy` on the deferred service being started. Because that service has no process yet, the health check can dereference a nil process and break the `/start` request.

## Validation

- `bazel test //deferred:deferred_service_test --test_output=errors --nocache_test_results` from `tests/`
- `bazel test //... --test_output=errors` from `tests/` (43 tests passed)
