### PR TITLE
Bind-only ports and support for so_reuseport_aware on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.ijwb/
+
 bazel-*
 MODULE.bazel.lock
 examples/MODULE.bazel.lock

--- a/cmd/svcinit/BUILD.bazel
+++ b/cmd/svcinit/BUILD.bazel
@@ -1,9 +1,11 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "svcinit_lib",
     srcs = [
         "main.go",
+        "reserve_reusable_port_unix.go",
+        "reserve_reusable_port_windows.go",
         "set_sockopts_for_port_assignment_unix.go",
         "set_sockopts_for_port_assignment_windows.go",
     ],
@@ -49,8 +51,17 @@ go_library(
         "@rules_go//go/platform:solaris": [
             "@org_golang_x_sys//unix",
         ],
+        "@rules_go//go/platform:windows": [
+            "@org_golang_x_sys//windows",
+        ],
         "//conditions:default": [],
     }),
+)
+
+go_test(
+    name = "svcinit_test",
+    srcs = ["reserve_reusable_port_test.go"],
+    embed = [":svcinit_lib"],
 )
 
 go_binary(

--- a/cmd/svcinit/main.go
+++ b/cmd/svcinit/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"maps"
 	"math"
@@ -124,8 +125,9 @@ func main() {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	must(err)
 
-	ports, err := assignPorts(unversionedSpecs)
+	ports, reservedPorts, err := assignPorts(unversionedSpecs)
 	must(err)
+	defer closeReservedPorts(reservedPorts)
 
 	svcctlPort := listener.Addr().(*net.TCPAddr).Port
 	svcctlPortStr := strconv.Itoa(svcctlPort)
@@ -374,9 +376,10 @@ func readServiceSpecs(
 func assignPorts(
 	serviceSpecs map[string]svclib.ServiceSpec,
 ) (
-	svclib.Ports, error,
+	svclib.Ports, map[string][]io.Closer, error,
 ) {
-	var toClose []net.Listener
+	var toClose []io.Closer
+	reservedPorts := map[string][]io.Closer{}
 	ports := svclib.Ports{}
 
 	for label, spec := range serviceSpecs {
@@ -386,34 +389,49 @@ func assignPorts(
 		}
 
 		// Note, this can cause collisions. So be careful!
-		// To avoid port collisions, set the `so_reuseport_aware` option on the service definition
-		// and use the SO_REUSEPORT socket option in your services.
+		// To avoid port collisions, set so_reuseport_aware on the service definition
+		// and use SO_REUSEPORT on Unix or SO_REUSEADDR on Windows in your services.
 		for portName, port := range namedPorts {
-			// We do a bit of a dance here to set SO_LINGER to 0. For details, see
-			// https://stackoverflow.com/questions/71975992/what-really-is-the-linger-time-that-can-be-set-with-so-linger-on-sockets
-			lc := net.ListenConfig{
-				Control: func(network, address string, conn syscall.RawConn) error {
-					var setSockoptErr error
-					err := conn.Control(func(fd uintptr) {
-						setSockoptErr = setSockoptsForPortAssignment(fd, &syscall.Linger{
-							Onoff:  1,
-							Linger: 0,
+			var reservedPort io.Closer
+			var err error
+			if spec.SoReuseportAware {
+				requestedPort, parseErr := strconv.Atoi(port)
+				if parseErr != nil || requestedPort < 0 || requestedPort > 65535 {
+					return nil, nil, fmt.Errorf("invalid port %q for %s", port, label)
+				}
+				reservedPort, port, err = reserveReusablePort(requestedPort)
+				if err != nil {
+					return nil, nil, err
+				}
+			} else {
+				// We do a bit of a dance here to set SO_LINGER to 0. For details, see
+				// https://stackoverflow.com/questions/71975992/what-really-is-the-linger-time-that-can-be-set-with-so-linger-on-sockets
+				lc := net.ListenConfig{
+					Control: func(network, address string, conn syscall.RawConn) error {
+						var setSockoptErr error
+						err := conn.Control(func(fd uintptr) {
+							setSockoptErr = setSockoptsForPortAssignment(fd, &syscall.Linger{
+								Onoff:  1,
+								Linger: 0,
+							})
 						})
-					})
-					if err != nil {
-						return err
-					}
-					return setSockoptErr
-				},
-			}
+						if err != nil {
+							return err
+						}
+						return setSockoptErr
+					},
+				}
 
-			listener, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:"+port)
-			if err != nil {
-				return nil, err
-			}
-			_, port, err = net.SplitHostPort(listener.Addr().String())
-			if err != nil {
-				return nil, err
+				listener, listenErr := lc.Listen(context.Background(), "tcp", "127.0.0.1:"+port)
+				if listenErr != nil {
+					return nil, nil, listenErr
+				}
+				_, port, err = net.SplitHostPort(listener.Addr().String())
+				if err != nil {
+					listener.Close()
+					return nil, nil, err
+				}
+				reservedPort = listener
 			}
 
 			qualifiedPortName := label
@@ -442,15 +460,17 @@ func assignPorts(
 			}
 
 			if !spec.SoReuseportAware {
-				toClose = append(toClose, listener)
+				toClose = append(toClose, reservedPort)
+			} else {
+				reservedPorts[label] = append(reservedPorts[label], reservedPort)
 			}
 		}
 	}
 
-	for _, listener := range toClose {
-		err := listener.Close()
+	for _, reservedPort := range toClose {
+		err := reservedPort.Close()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -481,10 +501,20 @@ func assignPorts(
 
 	serializedPorts, err := ports.Marshal()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	os.Setenv("ASSIGNED_PORTS", string(serializedPorts))
-	return ports, nil
+	return ports, reservedPorts, nil
+}
+
+func closeReservedPorts(reservedPorts map[string][]io.Closer) {
+	for label, ports := range reservedPorts {
+		for _, port := range ports {
+			if err := port.Close(); err != nil {
+				log.Printf("failed to close reusable port reservation for %s: %v\n", label, err)
+			}
+		}
+	}
 }
 
 func augmentServiceSpecs(

--- a/cmd/svcinit/reserve_reusable_port_test.go
+++ b/cmd/svcinit/reserve_reusable_port_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"net"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestReusablePortReservation(t *testing.T) {
+	reservation, port, err := reserveReusablePort(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reservation.Close()
+
+	unawareListener, err := net.Listen("tcp4", "127.0.0.1:"+port)
+	if err == nil {
+		unawareListener.Close()
+		t.Fatal("listener without a reusable-port option unexpectedly claimed the reserved port")
+	}
+
+	lc := net.ListenConfig{
+		Control: func(network, address string, conn syscall.RawConn) error {
+			var setSockoptErr error
+			err := conn.Control(func(fd uintptr) {
+				setSockoptErr = setSockoptsForPortAssignment(fd, &syscall.Linger{
+					Onoff:  1,
+					Linger: 0,
+				})
+			})
+			if err != nil {
+				return err
+			}
+			return setSockoptErr
+		},
+	}
+	listener, err := lc.Listen(context.Background(), "tcp4", "127.0.0.1:"+port)
+	if err != nil {
+		t.Fatalf("listen on reserved port: %v", err)
+	}
+	defer listener.Close()
+
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		conn.Close()
+		acceptErr <- nil
+	}()
+
+	conn, err := net.DialTimeout("tcp4", "127.0.0.1:"+port, time.Second)
+	if err != nil {
+		t.Fatalf("dial service listener: %v", err)
+	}
+	conn.Close()
+
+	select {
+	case err := <-acceptErr:
+		if err != nil {
+			t.Fatalf("accept from service listener: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("connection was not accepted by the service listener")
+	}
+}

--- a/cmd/svcinit/reserve_reusable_port_unix.go
+++ b/cmd/svcinit/reserve_reusable_port_unix.go
@@ -1,0 +1,56 @@
+//go:build unix
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"syscall"
+)
+
+func reserveReusablePort(port int) (io.Closer, string, error) {
+	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, syscall.IPPROTO_TCP)
+	if err != nil {
+		return nil, "", fmt.Errorf("socket: %w", err)
+	}
+	syscall.CloseOnExec(fd)
+
+	file := os.NewFile(uintptr(fd), "rules_itest_reserved_reuseport")
+	success := false
+	defer func() {
+		if !success {
+			file.Close()
+		}
+	}()
+
+	// Do not set SO_REUSEADDR here. Go TCP listeners enable it by default on
+	// Linux, where it would allow an unaware listener to claim a bind-only
+	// reservation. SO_REUSEPORT alone allows the aware service to share it.
+	if err := setSockoptsForPortAssignment(uintptr(fd), &syscall.Linger{
+		Onoff:  1,
+		Linger: 0,
+	}); err != nil {
+		return nil, "", fmt.Errorf("set reusable reservation socket options: %w", err)
+	}
+
+	if err := syscall.Bind(fd, &syscall.SockaddrInet4{
+		Port: port,
+		Addr: [4]byte{127, 0, 0, 1},
+	}); err != nil {
+		return nil, "", fmt.Errorf("bind reusable reservation socket: %w", err)
+	}
+
+	addr, err := syscall.Getsockname(fd)
+	if err != nil {
+		return nil, "", fmt.Errorf("getsockname reusable reservation socket: %w", err)
+	}
+	tcpAddr, ok := addr.(*syscall.SockaddrInet4)
+	if !ok {
+		return nil, "", fmt.Errorf("getsockname returned %T, expected *syscall.SockaddrInet4", addr)
+	}
+
+	success = true
+	return file, strconv.Itoa(tcpAddr.Port), nil
+}

--- a/cmd/svcinit/reserve_reusable_port_windows.go
+++ b/cmd/svcinit/reserve_reusable_port_windows.go
@@ -1,0 +1,67 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+type windowsPortReservation struct {
+	socket windows.Handle
+}
+
+func (r *windowsPortReservation) Close() error {
+	return windows.Closesocket(r.socket)
+}
+
+func reserveReusablePort(port int) (io.Closer, string, error) {
+	socket, err := windows.WSASocket(
+		windows.AF_INET,
+		windows.SOCK_STREAM,
+		windows.IPPROTO_TCP,
+		nil,
+		0,
+		windows.WSA_FLAG_OVERLAPPED|windows.WSA_FLAG_NO_HANDLE_INHERIT,
+	)
+	if err != nil {
+		return nil, "", fmt.Errorf("socket: %w", err)
+	}
+
+	success := false
+	defer func() {
+		if !success {
+			windows.Closesocket(socket)
+		}
+	}()
+
+	if err := setSockoptsForPortAssignment(uintptr(socket), &syscall.Linger{
+		Onoff:  1,
+		Linger: 0,
+	}); err != nil {
+		return nil, "", fmt.Errorf("set reusable reservation socket options: %w", err)
+	}
+
+	if err := windows.Bind(socket, &windows.SockaddrInet4{
+		Port: port,
+		Addr: [4]byte{127, 0, 0, 1},
+	}); err != nil {
+		return nil, "", fmt.Errorf("bind reusable reservation socket: %w", err)
+	}
+
+	addr, err := windows.Getsockname(socket)
+	if err != nil {
+		return nil, "", fmt.Errorf("getsockname reusable reservation socket: %w", err)
+	}
+	tcpAddr, ok := addr.(*windows.SockaddrInet4)
+	if !ok {
+		return nil, "", fmt.Errorf("getsockname returned %T, expected *windows.SockaddrInet4", addr)
+	}
+
+	success = true
+	return &windowsPortReservation{socket: socket}, strconv.Itoa(tcpAddr.Port), nil
+}

--- a/cmd/svcinit/set_sockopts_for_port_assignment_windows.go
+++ b/cmd/svcinit/set_sockopts_for_port_assignment_windows.go
@@ -5,6 +5,12 @@ package main
 import "syscall"
 
 func setSockoptsForPortAssignment(fd uintptr, l *syscall.Linger) error {
-	// Windows (even WSL) does not seem to support SO_REUSEPORT
-	return syscall.SetsockoptLinger(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_LINGER, l)
+	err := syscall.SetsockoptLinger(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_LINGER, l)
+	if err != nil {
+		return err
+	}
+
+	// Windows has no SO_REUSEPORT. SO_REUSEADDR allows the service listener to
+	// bind while svcinit holds a bind-only reservation socket.
+	return syscall.SetsockoptInt(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
 }

--- a/docs/itest.md
+++ b/docs/itest.md
@@ -19,6 +19,13 @@ query:enable-reload --@rules_itest//:enable_per_service_reload
 In addition, if the `hot_reloadable` attribute is set on an `itest_service`, the service manager will
 forward the ibazel hot-reload notification over stdin instead of restarting the service.
 
+# Reusable port reservations
+
+For each service with `so_reuseport_aware = True`, the service manager adds
+`RULES_ITEST_ENABLE_SO_REUSEPORT=1` to that service's environment. Services can use this signal to
+enable the socket option required to share their bind-only port reservation: `SO_REUSEPORT` on Unix
+or `SO_REUSEADDR` on Windows. The option must be set before binding the service socket.
+
 # Service control
 
 The service manager exposes a HTTP server on `http://127.0.0.1:{SVCCTL_PORT}`. It can be used to
@@ -75,7 +82,7 @@ All [common binary attributes](https://bazel.build/reference/be/common-definitio
 | <a id="itest_service-port"></a>port |  Internal.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="itest_service-shutdown_signal"></a>shutdown_signal |  The signal to send to the service when it needs to be shut down. Valid values are: SIGTERM and SIGKILL. SIGTERM is necessary to have proper coverage of services which needs to be gracefully terminated   | String | optional |  `"SIGTERM"`  |
 | <a id="itest_service-shutdown_timeout"></a>shutdown_timeout |  The duration to wait by default after sending the shutdown signal before forcefully killing the service. The syntax is based on common time duration with a number, followed by the time unit. For example, `200ms`, `1s`, `2m`, `3h`, `4d`. If not defined, the value of `_default_shutdown_timeout` will be used.   | String | optional |  `""`  |
-| <a id="itest_service-so_reuseport_aware"></a>so_reuseport_aware |  If set, the service manager will not release the autoassigned port. The service binary must use SO_REUSEPORT when binding it. This reduces the possibility of port collisions when running many service_tests in parallel, or when code binds port 0 without being aware of the port assignment mechanism.<br><br>Must only be set when `autoassign_port` is enabled or `named_ports` are used.   | Boolean | optional |  `False`  |
+| <a id="itest_service-so_reuseport_aware"></a>so_reuseport_aware |  If set, the service manager keeps a bind-only reservation for the autoassigned port for the service manager's lifetime. The service binary must use SO_REUSEPORT on Unix or SO_REUSEADDR on Windows when binding it. This reduces the possibility of port collisions when running many service_tests in parallel, or when code binds port 0 without being aware of the port assignment mechanism.<br><br>Must only be set when `autoassign_port` is enabled or `named_ports` are used.   | Boolean | optional |  `False`  |
 
 
 <a id="itest_service_group"></a>

--- a/private/itest.bzl
+++ b/private/itest.bzl
@@ -18,6 +18,13 @@ query:enable-reload --@rules_itest//:enable_per_service_reload
 In addition, if the `hot_reloadable` attribute is set on an `itest_service`, the service manager will
 forward the ibazel hot-reload notification over stdin instead of restarting the service.
 
+# Reusable port reservations
+
+For each service with `so_reuseport_aware = True`, the service manager adds
+`RULES_ITEST_ENABLE_SO_REUSEPORT=1` to that service's environment. Services can use this signal to
+enable the socket option required to share their bind-only port reservation: `SO_REUSEPORT` on Unix
+or `SO_REUSEADDR` on Windows. The option must be set before binding the service socket.
+
 # Service control
 
 The service manager exposes a HTTP server on `http://127.0.0.1:{SVCCTL_PORT}`. It can be used to
@@ -262,8 +269,9 @@ _itest_service_attrs = _itest_binary_attrs | {
         Named ports are accessible through the service-port mapping. For more details, see `autoassign_port`.""",
     ),
     "so_reuseport_aware": attr.bool(
-        doc = """If set, the service manager will not release the autoassigned port. The service binary must use SO_REUSEPORT when binding it.
-        This reduces the possibility of port collisions when running many service_tests in parallel, or when code binds port 0 without being
+        doc = """If set, the service manager keeps a bind-only reservation for the autoassigned port for the service manager's lifetime.
+        The service binary must use SO_REUSEPORT on Unix or SO_REUSEADDR on Windows when binding it. This reduces the possibility of port
+        collisions when running many service_tests in parallel, or when code binds port 0 without being
         aware of the port assignment mechanism.
 
         Must only be set when `autoassign_port` is enabled or `named_ports` are used.""",

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -265,6 +265,9 @@ func initializeServiceCmd(ctx context.Context, instance *ServiceInstance) error 
 	for k, v := range s.Env {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}
+	if s.SoReuseportAware {
+		cmd.Env = append(cmd.Env, "RULES_ITEST_ENABLE_SO_REUSEPORT=1")
+	}
 	cmd.Stdout = logger.New(s.Label+"> ", s.Color, os.Stdout)
 	cmd.Stderr = logger.New(s.Label+"> ", s.Color, os.Stderr)
 

--- a/tests/go_service/BUILD.bazel
+++ b/tests/go_service/BUILD.bazel
@@ -45,6 +45,9 @@ go_library(
         "@rules_go//go/platform:solaris": [
             "@org_golang_x_sys//unix",
         ],
+        "@rules_go//go/platform:windows": [
+            "@org_golang_x_sys//windows",
+        ],
         "//conditions:default": [],
     }),
 )

--- a/tests/go_service/main.go
+++ b/tests/go_service/main.go
@@ -18,7 +18,11 @@ func main() {
 	busyWaitTime := flag.Duration("busy-time", 0, "How long to busy-wait before binding the port")
 	dieAfter := flag.Duration("die-after", 0, "How long to wait before self-destructing")
 	fileToOpen := flag.String("file-to-open", "", "A file to open to check runfiles")
-	soReuseport := flag.Bool("so-reuseport", false, "If true, sets SO_REUSEPORT when binding the address")
+	soReuseport := flag.Bool(
+		"so-reuseport",
+		os.Getenv("RULES_ITEST_ENABLE_SO_REUSEPORT") == "1",
+		"If true, sets the platform's reusable-port socket option when binding the address",
+	)
 	port := flag.String("port", "", "Port to bind")
 
 	flag.Parse()

--- a/tests/go_service/serve_windows.go
+++ b/tests/go_service/serve_windows.go
@@ -2,11 +2,38 @@
 
 package main
 
-import "net/http"
+import (
+	"context"
+	"log"
+	"net"
+	"net/http"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
 
 func serve(port string, soReuseport bool) {
-	if soReuseport {
-		panic("SO_REUSEPORT not supported on Windows!")
+	lc := net.ListenConfig{
+		Control: func(network, address string, conn syscall.RawConn) error {
+			if !soReuseport {
+				return nil
+			}
+
+			var setSockoptErr error
+			err := conn.Control(func(fd uintptr) {
+				// FIX: Cast fd directly to syscall.Handle instead of int
+				setSockoptErr = syscall.SetsockoptInt(syscall.Handle(fd), syscall.SOL_SOCKET, windows.SO_REUSEADDR, 1)
+			})
+			if err != nil {
+				return err
+			}
+			return setSockoptErr
+		},
 	}
-	http.ListenAndServe("127.0.0.1:"+port, nil)
+
+	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:"+port)
+	if err != nil {
+		log.Fatal(err)
+	}
+	http.Serve(l, nil)
 }

--- a/tests/so_reuseport/BUILD.bazel
+++ b/tests/so_reuseport/BUILD.bazel
@@ -3,15 +3,9 @@ load("@rules_go//go:def.bzl", "go_test")
 load("@rules_itest//:itest.bzl", "itest_service", "service_test")
 load("//:must_fail.bzl", "must_fail")
 
-NOT_WINDOWS = select({
-    "@platforms//os:windows": ["@platforms//:incompatible"],
-    "//conditions:default": [],
-})
-
 itest_service(
     name = "reuseport_service",
     args = [
-        "-so-reuseport",
         "-port",
         "$${PORT}",
     ],
@@ -23,7 +17,6 @@ itest_service(
         "named_port1",
     ],
     so_reuseport_aware = True,
-    target_compatible_with = NOT_WINDOWS,
 )
 
 itest_service(
@@ -38,14 +31,12 @@ itest_service(
     http_health_check_address = "http://127.0.0.1:$${PORT}",
     so_reuseport_aware = True,
     tags = ["manual"],
-    target_compatible_with = NOT_WINDOWS,
 )
 
 # TODO(zbarsky): this rule is busted, it isn't actually working correctly.
 # May need to bust out real bazel integration tests?
 must_fail(
     name = "no_reuseport_service_hygiene_test",
-    target_compatible_with = NOT_WINDOWS,
     test = "_no_reuseport_service_hygiene_test",
 )
 


### PR DESCRIPTION
## Summary

  Add Windows support for so_reuseport_aware and change reusable port reservations from listening sockets to bind-only sockets.

  ## Motivation

  On Windows, SO_REUSEADDR allows the service and reservation sockets to bind the same port, but it does not provide Unix-style SO_REUSEPORT connection distribution.

  Because the reservation socket was also listening, health-check connections could be routed to it instead of the service. The reservation never accepted those connections, causing health checks to time out even though the service had started successfully.

  ## Changes

  - Introduce platform-specific bind-only reusable port reservations:
      - SO_REUSEPORT on Unix.
      - SO_REUSEADDR on Windows.

  - Create Windows sockets with WSA_FLAG_NO_HANDLE_INHERIT.
  - Keep reservations open for the service manager’s lifetime without calling listen.
  - Preserve explicitly configured port values instead of always binding port 0.
  - Set RULES_ITEST_ENABLE_SO_REUSEPORT=1 only in the environment of services configured with so_reuseport_aware = True.
  - Update the test service to use that environment variable instead of an explicit command-line flag.
  - Add documentation for the environment variable and platform-specific socket behavior.
  - Add a regression test proving that connections reach the service listener while the bind-only reservation remains open.

  ## Validation

  - bazel test //cmd/svcinit:svcinit_test
  - bazel test //so_reuseport:so_reuseport_test //so_reuseport:so_reuseport_js_test
  - Windows cross-build of //cmd/svcinit:svcinit
  - Windows cross-build of //go_service:go_service
