### PR TITLE
Fix per-service reload with unchanged dependencies

### DIFF
--- a/runner/BUILD.bazel
+++ b/runner/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "runner",
@@ -16,4 +16,11 @@ go_library(
         "//runner/topological",
         "//svclib",
     ],
+)
+
+go_test(
+    name = "runner_test",
+    srcs = ["runner_test.go"],
+    embed = [":runner"],
+    deps = ["//svclib"],
 )

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -62,6 +62,12 @@ func (r *Runner) StartAll(serviceErrCh chan error) ([]topological.Task, error) {
 			return nil
 		}
 
+		// UpdateSpecs() keeps unchanged services running. Treat them as completed
+		// dependencies instead of attempting to start them a second time.
+		if service.isRunning() {
+			return nil
+		}
+
 		if terseOutput {
 			log.Printf("Starting %s\n", colorize(service.VersionedServiceSpec))
 		} else {

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1,0 +1,35 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"rules_itest/svclib"
+)
+
+func TestStartAllSkipsAlreadyRunningServices(t *testing.T) {
+	service := &ServiceInstance{
+		VersionedServiceSpec: svclib.VersionedServiceSpec{
+			ServiceSpec: svclib.ServiceSpec{
+				Type:  "service",
+				Label: "//:unchanged",
+			},
+		},
+		cmd: &exec.Cmd{
+			Args:    []string{"unchanged"},
+			Process: &os.Process{Pid: 1},
+		},
+	}
+	runner := &Runner{
+		ctx: context.Background(),
+		serviceInstances: map[string]*ServiceInstance{
+			service.Label: service,
+		},
+	}
+
+	if _, err := runner.StartAll(make(chan error, 1)); err != nil {
+		t.Fatalf("StartAll() returned an error for an already-running service: %v", err)
+	}
+}


### PR DESCRIPTION
UpdateSpecs intentionally leaves unchanged services running, but UpdateSpecsAndRestart subsequently calls StartAll for every service instance. Skip instances that are still running so they can satisfy dependencies without being started a second time.

Add a regression test that reproduces the previous already-running error.

Encountered this with ibazel where the main service was restarted but other services were not affected, resulting in :
```
panic: @@//test/itest:postgres_service is already running

goroutine 1 [running]:
main.must(...)
	external/rules_itest+/cmd/svcinit/main.go:35
main.main()
```